### PR TITLE
NO-TICKET: Fixing collection exporter with TypeInterface objects

### DIFF
--- a/src/Zynga/Framework/StorableObject/Collections/Exporters/V1/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Exporters/V1/Base.hh
@@ -78,6 +78,8 @@ abstract class Base<Tv> implements ExportInterface {
           } catch (Exception $e) {
             throw $e;
           }
+        } else if ($storableItem instanceof TypeInterface) {
+          $value = json_encode($storableItem->get());
         }
 
         if ($value !== null) {

--- a/src/Zynga/Framework/StorableObject/Collections/Vector/V1/ExporterTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Vector/V1/ExporterTest.hh
@@ -11,7 +11,11 @@ use
 ;
 use Zynga\Framework\StorableObject\V1\Test\Mock\Valid as ValidStorableObject;
 
+use Zynga\Framework\StorableObject\Collections\Vector\V1\Mock\ValidVectorMock as ValidVectorMock;
+use Zynga\Framework\Type\V1\StringBox;
+
 class ExporterTest extends CollectionTest {
+  
   protected function getCollection<Tv as StorableObjectInterface>(
     classname<Tv> $classname,
   ): StorableCollection<Tv> {
@@ -22,5 +26,18 @@ class ExporterTest extends CollectionTest {
   ): classname<StorableCollection<Tv>> {
     return Base::class;
   }
-
+  
+  public function testValidJSONFromTypeInterface(): void {
+    $collectionVector = new ValidVectorMock();
+    $stringBox1 = new StringBox();
+    $stringBox1->set('123');
+    $collectionVector->stringVector->add($stringBox1);
+    
+    $stringBox2 = new StringBox();
+    $stringBox2->set('234');
+    $collectionVector->stringVector->add($stringBox2);
+    
+    $targetJson = '{"stringVector":["123","234"]}';
+    $this->assertEquals($targetJson, $collectionVector->export()->asJSON());
+  }
 }

--- a/src/Zynga/Framework/StorableObject/Collections/Vector/V1/Mock/ValidVectorMock.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Vector/V1/Mock/ValidVectorMock.hh
@@ -1,0 +1,17 @@
+<?hh // strict
+namespace Zynga\Framework\StorableObject\Collections\Vector\V1\Mock;
+
+use Zynga\Framework\StorableObject\Collections\Vector\V1\Base as StorableVector;
+use Zynga\Framework\StorableObject\V1\Base as StorableObjectBase;
+use Zynga\Framework\Type\V1\StringBox;
+
+class ValidVectorMock extends StorableObjectBase {
+  public StorableVector<StringBox> $stringVector;
+  
+  public function __construct() {
+    parent::__construct();
+    
+    $this->stringVector = new StorableVector(StringBox::class);
+    $this->stringVector->setIsRequired(true);
+  }
+}


### PR DESCRIPTION
This will fix the issue where Zynga\Framework\StorableObject\Collections\Vector\V1\Base was failing to export an array of any base types (like StringBox, IntBox) to JSON. 