### PR TITLE
Changing Box constructors to call set over import functions since set properly calls setIsDefaultValue(false)

### DIFF
--- a/src/Zynga/Framework/Type/V1/UInt64Box.hh
+++ b/src/Zynga/Framework/Type/V1/UInt64Box.hh
@@ -21,7 +21,7 @@ class UInt64Box extends BaseBox {
     $this->setIsDefaultValue(true);
 
     if ($value !== null) {
-      $this->importFromInteger($value);
+      $this->set($value);
     }
 
   }

--- a/src/Zynga/Framework/Type/V1/UrlBox.hh
+++ b/src/Zynga/Framework/Type/V1/UrlBox.hh
@@ -12,7 +12,7 @@ class UrlBox extends StringBox {
     $result = str_replace($find, $replace, $this->_value);
 
     try {
-      $this->importFromString($result);
+      $this->set($result);
     } catch (FailedToImportFromStringException $exception) {
       return false;
     }


### PR DESCRIPTION
If you construct a box with a specific value, the box should know that it's value isn't the default value. Calling import in a constructor doesn't handle this properly, but set does. So I swapped the two boxes that were doing this to call set instead of importFromX.