### PR TITLE
NO-TICKET: Add curl generic function to Manager.hh

### DIFF
--- a/src/Zynga/Framework/IO/Web/V1/Curl/CurlInterface.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/CurlInterface.hh
@@ -1,0 +1,10 @@
+<?hh // strict
+
+namespace Zynga\Framework\IO\Web\V1\Curl;
+
+interface CurlInterface {
+  public function setOptionsArray(array<int, mixed> $options): bool;
+  public function execute(): mixed;
+  public function getInfo(int $optName): mixed;
+  public function close(): bool;
+}

--- a/src/Zynga/Framework/IO/Web/V1/Curl/CurlInterface.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/CurlInterface.hh
@@ -4,7 +4,7 @@ namespace Zynga\Framework\IO\Web\V1\Curl;
 
 interface CurlInterface {
   public function setOptionsArray(array<int, mixed> $options): bool;
-  public function execute(): mixed;
+  public function execute(): CurlResponsePayload;
   public function getInfo(int $optName): mixed;
   public function close(): bool;
 }

--- a/src/Zynga/Framework/IO/Web/V1/Curl/CurlRequest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/CurlRequest.hh
@@ -1,10 +1,11 @@
 <?hh // strict
 
 namespace Zynga\Framework\IO\Web\V1\Curl;
+
 use Zynga\Framework\Type\V1\UrlBox;
 
 class CurlRequest implements CurlInterface {
-  private mixed $curlHandle;
+  private resource $curlHandle;
   
   public function __construct(UrlBox $url) {
     $this->curlHandle = curl_init($url->get());
@@ -14,8 +15,17 @@ class CurlRequest implements CurlInterface {
     return curl_setopt_array($this->curlHandle, $options);
   }
 
-  public function execute(): mixed {
-    return curl_exec($this->curlHandle);
+  public function execute(): CurlResponsePayload {
+    $curlResult = curl_exec($this->curlHandle);
+    if(is_bool($curlResult)) {
+      return new CurlResponsePayload($curlResult, array());
+    }
+    
+    $curlResultArray = json_decode($curlResult, true);
+    if($curlResultArray == null) {
+      $curlResultArray = array();
+    }
+    return new CurlResponsePayload(true, $curlResultArray);
   }
 
   public function getInfo(int $optName): mixed {

--- a/src/Zynga/Framework/IO/Web/V1/Curl/CurlRequest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/CurlRequest.hh
@@ -1,0 +1,29 @@
+<?hh // strict
+
+namespace Zynga\Framework\IO\Web\V1\Curl;
+use Zynga\Framework\Type\V1\UrlBox;
+
+class CurlRequest implements CurlInterface {
+  private mixed $curlHandle;
+  
+  public function __construct(UrlBox $url) {
+    $this->curlHandle = curl_init($url->get());
+  }
+  
+  public function setOptionsArray(array<int, mixed> $options): bool {
+    return curl_setopt_array($this->curlHandle, $options);
+  }
+
+  public function execute(): mixed {
+    return curl_exec($this->curlHandle);
+  }
+
+  public function getInfo(int $optName): mixed {
+    return curl_getinfo($this->curlHandle, $optName);
+  }
+
+  public function close(): bool {
+    curl_close($this->curlHandle);
+    return true;
+  }
+}

--- a/src/Zynga/Framework/IO/Web/V1/Curl/CurlResponsePayload.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/CurlResponsePayload.hh
@@ -1,0 +1,13 @@
+<?hh // strict
+
+namespace Zynga\Framework\IO\Web\V1\Curl;
+
+class CurlResponsePayload {
+  public bool $success = false;
+  public array<string, mixed> $payload = array();
+  
+  public function __construct(bool $success, array<string, mixed> $payload) {
+    $this->success = $success;
+    $this->payload = $payload;
+  }
+}

--- a/src/Zynga/Framework/IO/Web/V1/Curl/MockedCurlRequest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/MockedCurlRequest.hh
@@ -5,10 +5,10 @@ namespace Zynga\Framework\IO\Web\V1\Curl;
 class MockedCurlRequest implements CurlInterface {
   
   private bool $setOptionsReturn = false;
-  private mixed $curlExecReturn;
+  private CurlResponsePayload $curlExecReturn;
   private mixed $curlInfoReturn;
   
-  public function __construct(bool $setOptionsReturn, mixed $curlExecReturn, mixed $curlInfoReturn) {
+  public function __construct(bool $setOptionsReturn, CurlResponsePayload $curlExecReturn, mixed $curlInfoReturn) {
     $this->setOptionsReturn = $setOptionsReturn;
     $this->curlExecReturn = $curlExecReturn;
     $this->curlInfoReturn = $curlInfoReturn;
@@ -18,7 +18,7 @@ class MockedCurlRequest implements CurlInterface {
     return $this->setOptionsReturn;
   }
 
-  public function execute(): mixed {
+  public function execute(): CurlResponsePayload {
     return $this->curlExecReturn;
   }
 

--- a/src/Zynga/Framework/IO/Web/V1/Curl/MockedCurlRequest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/MockedCurlRequest.hh
@@ -1,0 +1,33 @@
+<?hh // strict
+
+namespace Zynga\Framework\IO\Web\V1\Curl;
+
+class MockedCurlRequest implements CurlInterface {
+  
+  private bool $setOptionsReturn = false;
+  private mixed $curlExecReturn;
+  private mixed $curlInfoReturn;
+  
+  public function __construct(bool $setOptionsReturn, mixed $curlExecReturn, mixed $curlInfoReturn) {
+    $this->setOptionsReturn = $setOptionsReturn;
+    $this->curlExecReturn = $curlExecReturn;
+    $this->curlInfoReturn = $curlInfoReturn;
+  }
+  
+  public function setOptionsArray(array<int, mixed> $options): bool {
+    return $this->setOptionsReturn;
+  }
+
+  public function execute(): mixed {
+    return $this->curlExecReturn;
+  }
+
+  public function getInfo(int $optName): mixed {
+    return $this->curlInfoReturn;
+  }
+
+  public function close(): bool {
+    // noop
+    return true;
+  }
+}

--- a/src/Zynga/Framework/IO/Web/V1/Manager.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Manager.hh
@@ -19,6 +19,9 @@ use Zynga\Framework\Type\V1\UrlBox;
  * Lightweight class for managing Web IO
  */
 class Manager {
+  
+  public static bool $useMockCurl = false;
+  public static array<string, mixed> $useMockCurlResult = array();
 
   /**
    * Uploads $fileName to $uploadUrl using a PUT request
@@ -50,4 +53,25 @@ class Manager {
       throw new UnexpectedHttpCodeException((string)$returnCode);
     }
   }
+  
+  public static function makeCurlRequest(
+    UrlBox $uploadUrl,
+    Map<string, mixed> $postParams): array<string, mixed> {
+      if(self::$useMockCurl == false) {
+        $session = curl_init();
+        curl_setopt( $session, CURLOPT_URL, $uploadUrl->get());
+        curl_setopt( $session, CURLOPT_POST, true);
+        curl_setopt( $session, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt( $session, CURLOPT_POSTFIELDS, http_build_query($postParams));
+        curl_setopt( $session, CURLOPT_TIMEOUT, 5);
+        $result = json_decode(curl_exec($session), true);
+        if($result == null) {
+          $result = array();
+        }
+        curl_close($session);
+        return $result;
+      }
+      
+      return self::$useMockCurlResult;
+    }
 }

--- a/src/Zynga/Framework/IO/Web/V1/Manager.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Manager.hh
@@ -15,14 +15,20 @@ use
 ;
 use Zynga\Framework\Type\V1\UrlBox;
 
+use Zynga\Framework\IO\Web\V1\Curl\CurlInterface;
+use Zynga\Framework\IO\Web\V1\Curl\CurlRequest;
+use Zynga\Framework\IO\Web\V1\Curl\MockedCurlRequest;
+
 /**
  * Lightweight class for managing Web IO
  */
 class Manager {
-  
+    
   public static bool $useMockCurl = false;
-  public static array<string, mixed> $useMockCurlResult = array();
-
+  public static bool $setOptionsReturn = false;
+  public static mixed $curlExecReturn = array();
+  public static mixed $curlInfoReturn = array();
+  
   /**
    * Uploads $fileName to $uploadUrl using a PUT request
    *
@@ -54,24 +60,11 @@ class Manager {
     }
   }
   
-  public static function makeCurlRequest(
-    UrlBox $uploadUrl,
-    Map<string, mixed> $postParams): array<string, mixed> {
-      if(self::$useMockCurl == false) {
-        $session = curl_init();
-        curl_setopt( $session, CURLOPT_URL, $uploadUrl->get());
-        curl_setopt( $session, CURLOPT_POST, true);
-        curl_setopt( $session, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt( $session, CURLOPT_POSTFIELDS, http_build_query($postParams));
-        curl_setopt( $session, CURLOPT_TIMEOUT, 5);
-        $result = json_decode(curl_exec($session), true);
-        if($result == null) {
-          $result = array();
-        }
-        curl_close($session);
-        return $result;
-      }
-      
-      return self::$useMockCurlResult;
+  public static function getCurlRequest(UrlBox $url): CurlInterface {
+    if(self::$useMockCurl) {
+      return new MockedCurlRequest(self::$setOptionsReturn, self::$curlExecReturn, self::$curlInfoReturn);
     }
+    
+    return new CurlRequest($url);
+  }
 }

--- a/src/Zynga/Framework/IO/Web/V1/Manager.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Manager.hh
@@ -14,10 +14,10 @@ use
   Zynga\Framework\IO\Web\V1\Exception\UnexpectedHttpCode as UnexpectedHttpCodeException
 ;
 use Zynga\Framework\Type\V1\UrlBox;
-
 use Zynga\Framework\IO\Web\V1\Curl\CurlInterface;
 use Zynga\Framework\IO\Web\V1\Curl\CurlRequest;
 use Zynga\Framework\IO\Web\V1\Curl\MockedCurlRequest;
+use Zynga\Framework\IO\Web\V1\Curl\CurlResponsePayload;
 
 /**
  * Lightweight class for managing Web IO
@@ -26,7 +26,7 @@ class Manager {
     
   public static bool $useMockCurl = false;
   public static bool $setOptionsReturn = false;
-  public static mixed $curlExecReturn = array();
+  public static ?CurlResponsePayload $curlExecReturn;
   public static mixed $curlInfoReturn = array();
   
   /**
@@ -62,6 +62,10 @@ class Manager {
   
   public static function getCurlRequest(UrlBox $url): CurlInterface {
     if(self::$useMockCurl) {
+      if(self::$curlExecReturn == null) {
+        self::$curlExecReturn = new CurlResponsePayload(false, array());
+      }
+      
       return new MockedCurlRequest(self::$setOptionsReturn, self::$curlExecReturn, self::$curlInfoReturn);
     }
     

--- a/src/Zynga/Framework/IO/Web/V1/ManagerTest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/ManagerTest.hh
@@ -1,0 +1,30 @@
+<?hh // strict
+
+namespace Zynga\Framework\IO\Web\V1;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+use Zynga\Framework\Type\V1\UrlBox;
+
+class ManagerTest extends TestCase {
+  
+  public function testMakeCurlRequestWithMock(): void {
+    Manager::$useMockCurl = true;
+    Manager::$useMockCurlResult = array('success' => true);
+    $url = new UrlBox();
+    $url->set('https://www.zynga.com');
+    $postParams = Map{};
+    $result = Manager::makeCurlRequest($url, $postParams);
+    $this->assertEquals(1, count($result));
+    $this->assertTrue(array_key_exists('success', $result));
+    $this->assertTrue(($result['success'] == true));
+  }
+
+  public function testMakeCurlRequestWithoutMock(): void {
+    Manager::$useMockCurl = false;
+    $url = new UrlBox();
+    $url->set('https://www.zynga.com');
+    $postParams = Map{};
+    $result = Manager::makeCurlRequest($url, $postParams);
+    $this->assertEquals(0, count($result));
+  }
+}

--- a/src/Zynga/Framework/IO/Web/V1/ManagerTest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/ManagerTest.hh
@@ -5,26 +5,88 @@ namespace Zynga\Framework\IO\Web\V1;
 use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
 use Zynga\Framework\Type\V1\UrlBox;
 
+use Zynga\Framework\IO\Web\V1\Curl\CurlInterface;
+use Zynga\Framework\IO\Web\V1\Curl\CurlRequest;
+use Zynga\Framework\IO\Web\V1\Curl\MockedCurlRequest;
+
 class ManagerTest extends TestCase {
   
-  public function testMakeCurlRequestWithMock(): void {
-    Manager::$useMockCurl = true;
-    Manager::$useMockCurlResult = array('success' => true);
-    $url = new UrlBox();
-    $url->set('https://www.zynga.com');
-    $postParams = Map{};
-    $result = Manager::makeCurlRequest($url, $postParams);
-    $this->assertEquals(1, count($result));
-    $this->assertTrue(array_key_exists('success', $result));
-    $this->assertTrue(($result['success'] == true));
-  }
-
-  public function testMakeCurlRequestWithoutMock(): void {
+  <<__Override>>
+  public function tearDown(): void {
+    parent::tearDown();
     Manager::$useMockCurl = false;
+  }
+  
+  public function testMockedCurlRequestClassObject(): void {
+    $curlRequest = $this->getCurlRequest(true);
+    $this->assertEquals(MockedCurlRequest::class, get_class($curlRequest));
+  }
+  
+  public function testSettingOptionsOnMockedCurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(true);
+    $this->assertTrue($curlRequest->setOptionsArray(array()));
+  }
+  
+  public function testCurlResponseOnExecutingAMockedCurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(true);
+    $curlExecReturn = $curlRequest->execute();
+    invariant(is_array($curlExecReturn), 'CurlExecReturn is not an array');
+    $this->assertTrue(array_key_exists('success', $curlExecReturn));
+    $this->assertEquals(true, $curlExecReturn['success']);
+  }
+  
+  public function testGettingInfoOnMockedCurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(true);
+    $curlInfoReturn = $curlRequest->getInfo(CURLINFO_HTTP_CODE);
+    $this->assertEquals(200, $curlInfoReturn);
+  }
+  
+  public function testClosingAMockedCurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(true);
+    $this->assertTrue($curlRequest->close());
+  }
+  
+  public function testCurlRequestClassObject(): void {
+    $curlRequest = $this->getCurlRequest(false);
+    $this->assertEquals(CurlRequest::class, get_class($curlRequest));
+  }
+  
+  public function testSettingOptionsOnCurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(false);
+    $this->assertTrue($curlRequest->setOptionsArray(
+    array(
+      CURLOPT_RETURNTRANSFER => true
+    )));
+  }
+  
+  public function testCurlResponseOnExecutingACurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(false);
+    $this->assertTrue(($curlRequest->execute() == true));
+  }
+  
+  public function testGettingInfoOnCurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(false);
+    $curlRequest->execute();
+    $curlHttpCode = $curlRequest->getInfo(CURLINFO_HTTP_CODE);
+    $this->assertEquals(200, $curlHttpCode);
+  }
+  
+  public function testClosingACurlRequest(): void {
+    $curlRequest = $this->getCurlRequest(false);
+    $this->assertTrue($curlRequest->close());
+  }
+    
+  private function getCurlRequest(bool $useMock): CurlInterface {
+    Manager::$useMockCurl = $useMock;
+    if($useMock == true) {
+      Manager::$setOptionsReturn = true;
+      Manager::$curlExecReturn = array('success' => true);
+      Manager::$curlInfoReturn = 200;
+    }
+    
     $url = new UrlBox();
     $url->set('https://www.zynga.com');
-    $postParams = Map{};
-    $result = Manager::makeCurlRequest($url, $postParams);
-    $this->assertEquals(0, count($result));
+    $curlRequest = Manager::getCurlRequest($url);
+    return $curlRequest;
   }
 }


### PR DESCRIPTION
Adding a generic curl function that anyone can use. Check the unit tests on how it can be used with mocks