### PR TITLE
POK-37650: Fix: http can return 500 from service response code

### DIFF
--- a/src/Zynga/Framework/Service/V2/Handler/BaseTest.hh
+++ b/src/Zynga/Framework/Service/V2/Handler/BaseTest.hh
@@ -57,6 +57,25 @@ class BaseTest extends TestCase {
     $this->assertFalse($svc->response()->success()->get());
   }
 
+  public function testValid_FailureExceptionDoesNotChangeInRangeFailureCode(
+  ): void {
+    $obj = new MockEmptyHandler();
+    $svc = new ValidService();
+    $obj->setService($svc);
+    $e = new Exception('some-error-message');
+    $svc->response()->code->set(500);
+    $this->assertTrue($obj->handleFailureException($e));
+    $message = $svc->response()->message()->at(0);
+    if ($message instanceof StringBox) {
+      $this->assertEquals(
+        'Zynga\Framework\Exception\V1\Exception: some-error-message',
+        $message->get(),
+      );
+    }
+    $this->assertFalse($svc->response()->success()->get());
+    $this->assertTrue(500 == $svc->response()->code->get());
+  }
+
   public function testValid_HandleGenericSuccess(): void {
     $obj = new MockEmptyHandler();
     $svc = new ValidService();

--- a/src/Zynga/Framework/Service/V2/Handler/Http.hh
+++ b/src/Zynga/Framework/Service/V2/Handler/Http.hh
@@ -2,15 +2,21 @@
 
 namespace Zynga\Framework\Service\V2\Handler;
 
-use Zynga\Framework\Environment\HTTP\HeaderContainer\V2\HeaderContainer as HttpHeaderContainer;
-use Zynga\Framework\Environment\HTTP\HeaderContainer\V2\Interfaces\HeaderContainerInterface as HttpHeaderContainerInterface;
+use
+  Zynga\Framework\Environment\HTTP\HeaderContainer\V2\HeaderContainer as HttpHeaderContainer
+;
+use
+  Zynga\Framework\Environment\HTTP\HeaderContainer\V2\Interfaces\HeaderContainerInterface as HttpHeaderContainerInterface
+;
 use Zynga\Framework\Environment\SuperGlobals\V1\SuperGlobals;
 use Zynga\Framework\Exception\V1\Exception;
 use Zynga\Framework\Logging\V1\StaticLogger;
 use Zynga\Framework\Service\V2\Handler\Base as BaseHandler;
 use Zynga\Framework\Service\V2\Interfaces\ServiceInterface;
 use Zynga\Framework\Service\V2\Response\Failure as ResponseFailure;
-use Zynga\Framework\StorableObject\V1\Exceptions\MissingDataFromExportDataException;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\MissingDataFromExportDataException
+;
 use Zynga\Framework\StorableObject\V1\Exceptions\NoFieldsFoundException;
 use Zynga\Framework\Type\V1\HttpResponseCodeBox;
 use Zynga\Framework\Type\V1\StringBox;
@@ -118,8 +124,11 @@ class Http extends BaseHandler {
     if ($service instanceof ServiceInterface) {
 
       parent::handleGenericFailure();
-
-      $service->response()->code()->set(HttpResponseCodeBox::FAILURE_BAD_REQUEST);
+      if ($service->response()->code()->isDefaultValue()[0] === true) {
+        $service->response()
+          ->code()
+          ->set(HttpResponseCodeBox::FAILURE_BAD_REQUEST);
+      }
 
       return true;
 
@@ -135,8 +144,8 @@ class Http extends BaseHandler {
 
     $failure = new ResponseFailure();
     $failure->success()->set(false);
-    if ( $service->response()->code()->get() >= HttpResponseCodeBox::FAILURE_RANGE_START &&
-        $service->response()->code()->get() <= HttpResponseCodeBox::FAILURE_RANGE_END ) {
+    if ($service->response()->code()->get() >= HttpResponseCodeBox::FAILURE_RANGE_START &&
+        $service->response()->code()->get() <= HttpResponseCodeBox::FAILURE_RANGE_END) {
       $failure->code()->set($service->response()->code()->get());
     } else {
       $failure->code()->set(HttpResponseCodeBox::FAILURE_BAD_REQUEST);


### PR DESCRIPTION
handleGenericFailure was setting the service's response code to 400 on a success=false
In service/base.hh handleRequest called handleGenericFailure before handleResponse
so the service's original response code would be overwritten and returned.

Now handleGenericFailure only sets the service response code if it is not already set.
Note that createHttpCodeResponseFailure masks down the error code in handleResponse after the handleGenericFailure call.

Added unit test which catches the service code change in handleGenericFailure.
Added unit test around other related functions as further precautions to preserve the service code being changed unexpectedly.