### PR TITLE
Date time import support

### DIFF
--- a/src/Zynga/Framework/Type/V1/DateTimeBox.hh
+++ b/src/Zynga/Framework/Type/V1/DateTimeBox.hh
@@ -58,7 +58,7 @@ class DateTimeBox extends BaseBox {
   public function set(mixed $value): bool {
     if ($value instanceof DateTime) {
       $this->value = $value;
-      $this->setIsDefaultValue(true);
+      $this->setIsDefaultValue(false);
       return true;
     } else {
       return parent::set($value);

--- a/src/Zynga/Framework/Type/V1/DateTimeBox.hh
+++ b/src/Zynga/Framework/Type/V1/DateTimeBox.hh
@@ -55,6 +55,17 @@ class DateTimeBox extends BaseBox {
   }
 
   <<__Override>>
+  public function set(mixed $value): bool {
+    if ($value instanceof DateTime) {
+      $this->value = $value;
+      $this->setIsDefaultValue(true);
+      return true;
+    } else {
+      return parent::set($value);
+    }
+  }
+
+  <<__Override>>
   protected function importFromBool(bool $value): bool {
     throw new FailedToImportFromBoolException();
   }

--- a/src/Zynga/Framework/Type/V1/DateTimeBoxTest.hh
+++ b/src/Zynga/Framework/Type/V1/DateTimeBoxTest.hh
@@ -50,7 +50,6 @@ class DateTimeBoxTest extends StringBoxTest {
         $this->assertTrue(true);
       }
     }
-
   }
 
   public function testCanImportFromValidString(): void {
@@ -63,6 +62,11 @@ class DateTimeBoxTest extends StringBoxTest {
         $this->assertTrue(false);
       }
     }
+  }
+
+  public function testCanImportFromDateTime(): void {
+    $dateTimeBox = new DateTimeBox();
+    $this->assertTrue($dateTimeBox->set(DateTime::createFromFormat('U', time())));
   }
 
   public function testToStringDefaultValueIsUnknownDateTime(): void {


### PR DESCRIPTION
Motivation
----
The DateTimeBox not having support for setting the wrapped native type did not make sense. This becomes an issue when deserializing an object that could pass in a DateTime object.

Therefore, this adds support to it.