### PR TITLE
Versioning Storable Collection Map to V2

### DIFF
--- a/src/Zynga/Framework/StorableObject/Collections/Map/V1/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V1/Base.hh
@@ -23,8 +23,6 @@ use
 
 use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
 
-// Existing: TBD if we will be able to remove the below
-use Zynga\Framework\StorableObject\V1\Fields;
 use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
 
 class Base<Tk, Tv> implements StorableMapCollection<Tk, Tv> {

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Base.hh
@@ -1,0 +1,188 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2;
+
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Exporter\Base as Exporter
+;
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Importer\Box as BoxImporter
+;
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Importer\Storable as StorableImporter
+;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+use Zynga\Framework\StorableObject\V1\Fields;
+use Zynga\Framework\StorableObject\V1\Fields\Generic as FieldsGeneric;
+use Zynga\Framework\StorableObject\V1\Interfaces\ExportInterface;
+use Zynga\Framework\StorableObject\V1\Interfaces\FieldsInterface;
+use Zynga\Framework\StorableObject\V1\Interfaces\ImportInterface;
+use Zynga\Framework\StorableObject\V1\Interfaces\StorableObjectInterface;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+
+class Base<Tv> implements StorableMapCollection<Tv> {
+  /**
+   * Native Map only supports int keys or string keys
+   * https://docs.hhvm.com/hack/reference/class/HH.Map/
+   * We are forcing it to support only string as for data with
+   * int keys we can make use of StorableVector
+   */
+  private Map<string, Tv> $map;
+  private bool $isRequired;
+  private bool $isDefaultValue;
+
+  public function __construct(private classname<Tv> $valueType) {
+    $interfaces = class_implements($valueType);
+    if (array_key_exists(StorableObjectInterface::class, $interfaces) === false &&
+        array_key_exists(TypeInterface::class, $interfaces) === false) {
+      throw new OperationNotSupportedException(
+        'Collection only support the following types for Map values:'.
+        StorableObjectInterface::class.
+        ', '.
+        TypeInterface::class,
+      );
+    }
+
+    $this->isRequired = false;
+    $this->isDefaultValue = true;
+    $this->map = Map {};
+  }
+
+  public function clear(): bool {
+    $this->map->clear();
+    $this->isDefaultValue = true;
+    return true;
+  }
+
+  public function isEmpty(): bool {
+    if ($this->map->count() == 0) {
+      return true;
+    }
+    return false;
+  }
+
+  public function count(): int {
+    return $this->map->count();
+  }
+
+  public function items(): Map<string, Tv> {
+    return $this->map;
+  }
+
+  public function add(Pair<string, Tv> $pair): this {
+    $this->map->add($pair);
+    return $this;
+  }
+
+  public function set(string $k, Tv $v): this {
+    $this->map->set($k, $v);
+    return $this;
+  }
+
+  public function addAll(?Traversable<Pair<string, Tv>> $iterable): this {
+    $this->map->addAll($iterable);
+    return $this;
+  }
+
+  public function setAll(?KeyedTraversable<string, Tv> $iterable): this {
+    $this->map->setAll($iterable);
+    return $this;
+  }
+
+  public function remove(string $key): this {
+    $this->map->remove($key);
+    return $this;
+  }
+
+  public function removeKey(string $key): this {
+    $this->map->removeKey($key);
+    return $this;
+  }
+
+  public function get(string $key): ?Tv {
+
+    if ($this->map->containsKey($key) === true) {
+      return $this->map[$key];
+    }
+
+    return null;
+
+  }
+
+  public function at(string $key): Tv {
+    return $this->map->at($key);
+  }
+
+  public function containsKey<Tu super string>(Tu $key): bool {
+    return $this->map->containsKey($key);
+  }
+
+  public function toArray(): array<string, Tv> {
+    return $this->map->toArray();
+  }
+
+  public function setIsDefaultValue(bool $tf): bool {
+    $this->isDefaultValue = $tf;
+    return true;
+  }
+
+  public function isDefaultValue(): (bool, Vector<string>) {
+
+    $defaultFields = Vector {};
+
+    $hadNonDefault = false;
+
+    foreach ($this->map as $key => $value) {
+      list($f_isRequired, $f_isDefaultValue) =
+        FieldsGeneric::getIsRequiredAndIsDefaultValue($value);
+
+      if ($f_isDefaultValue === true) {
+        $defaultFields[] = $key;
+      } else {
+        $hadNonDefault = true;
+      }
+    }
+
+    $isDefaultValue = $this->isDefaultValue;
+
+    if ($hadNonDefault === true) {
+      $isDefaultValue = false;
+    }
+
+    return tuple($isDefaultValue, $defaultFields);
+
+  }
+
+  public function fields(): FieldsInterface {
+    $fields = new Fields($this);
+    return $fields;
+  }
+
+  public function import(): ImportInterface {
+    $interfaces = class_implements($this->valueType);
+    if (array_key_exists(StorableObjectInterface::class, $interfaces)) {
+      return new StorableImporter($this, $this->valueType);
+    }
+
+    return new BoxImporter($this, $this->valueType);
+  }
+
+  public function export(): ExportInterface {
+    $exporter = new Exporter($this);
+    return $exporter;
+  }
+
+  public function setIsRequired(bool $isRequired): bool {
+    $this->isRequired = $isRequired;
+    return true;
+  }
+
+  public function getIsRequired(): bool {
+    return $this->isRequired;
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/BaseTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/BaseTest.hh
@@ -4,20 +4,19 @@ namespace Zynga\Framework\StorableObject\Collections\Map\V2;
 
 use \OutOfBoundsException;
 use Zynga\Framework\StorableObject\Collections\Map\V2\Base as MapBase;
-use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\UnsupportedType;
 use
   Zynga\Framework\StorableObject\Collections\Map\V2\Importer\Box as BoxImporter
 ;
 use
   Zynga\Framework\StorableObject\Collections\Map\V2\Importer\Storable as StorableImporter
 ;
-use
-  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
-;
 use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
 use Zynga\Framework\StorableObject\V1\Interfaces\ExportInterface;
 use Zynga\Framework\StorableObject\V1\Interfaces\FieldsInterface;
 use Zynga\Framework\StorableObject\V1\Interfaces\ImportInterface;
+use
+  Zynga\Framework\StorableObject\V1\Test\Mock\UnsupportedCollectionValueType
+;
 use Zynga\Framework\StorableObject\V1\Test\Mock\Valid as ValidStorableObject;
 use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
 use Zynga\Framework\Type\V1\StringBox;
@@ -33,8 +32,8 @@ class BaseTest extends TestCase {
   }
 
   public function testConstructionFailsForUnsupportedType(): void {
-    $this->expectException(OperationNotSupportedException::class);
-    $collection = new MapBase(UnsupportedType::class);
+    $this->expectException(UnsupportedTypeException::class);
+    $collection = new MapBase(UnsupportedCollectionValueType::class);
   }
 
   public function testAddInsertsItemWithNewKey(): void {

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/BaseTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/BaseTest.hh
@@ -1,0 +1,335 @@
+<?hh //strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2;
+
+use \OutOfBoundsException;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as MapBase;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\UnsupportedType;
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Importer\Box as BoxImporter
+;
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Importer\Storable as StorableImporter
+;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+use Zynga\Framework\StorableObject\V1\Interfaces\ExportInterface;
+use Zynga\Framework\StorableObject\V1\Interfaces\FieldsInterface;
+use Zynga\Framework\StorableObject\V1\Interfaces\ImportInterface;
+use Zynga\Framework\StorableObject\V1\Test\Mock\Valid as ValidStorableObject;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+use Zynga\Framework\Type\V1\StringBox;
+
+class BaseTest extends TestCase {
+  const string KEY_1 = "key1";
+  const string KEY_2 = "key2";
+  const string KEY_3 = "key3";
+
+  public function testConstructionWithBoxSucceeds(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $this->addToAssertionCount(1);
+  }
+
+  public function testConstructionFailsForUnsupportedType(): void {
+    $this->expectException(OperationNotSupportedException::class);
+    $collection = new MapBase(UnsupportedType::class);
+  }
+
+  public function testAddInsertsItemWithNewKey(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $box1 = new ValidStorableObject();
+    $box1->example_uint64->set(12);
+    $collection->add(Pair {self::KEY_1, $box1});
+
+    $box2 = new ValidStorableObject();
+    $box2->example_uint64->set(23);
+    $collection->add(Pair {self::KEY_2, $box2});
+
+    $this->assertEquals(2, $collection->count());
+    $this->assertEquals($box1, $collection->at(self::KEY_1));
+    $this->assertEquals($box2, $collection->at(self::KEY_2));
+  }
+
+  public function testAddOverwritesItemWithExistingKey(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $box1 = new ValidStorableObject();
+    $box1->example_uint64->set(12);
+    $collection->add(Pair {self::KEY_1, $box1});
+
+    $this->assertEquals(1, $collection->count());
+    $this->assertEquals($box1, $collection->at(self::KEY_1));
+
+    $box2 = new ValidStorableObject();
+    $box2->example_uint64->set(23);
+    $collection->add(Pair {self::KEY_1, $box2});
+
+    $this->assertEquals(1, $collection->count());
+    $this->assertEquals($box2, $collection->at(self::KEY_1));
+  }
+
+  public function testSetInsertsItemWithNewKey(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $box1 = new ValidStorableObject();
+    $box1->example_uint64->set(12);
+    $collection->add(Pair {self::KEY_1, $box1});
+
+    $box2 = new ValidStorableObject();
+    $box2->example_uint64->set(23);
+    $collection->add(Pair {self::KEY_2, $box2});
+
+    $this->assertEquals(2, $collection->count());
+    $this->assertEquals($box1, $collection->at(self::KEY_1));
+    $this->assertEquals($box2, $collection->at(self::KEY_2));
+  }
+
+  public function testSetOverwritesItemWithExistingKey(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $box1 = new ValidStorableObject();
+    $box1->example_uint64->set(12);
+    $collection->add(Pair {self::KEY_1, $box1});
+
+    $this->assertEquals(1, $collection->count());
+    $this->assertEquals($box1, $collection->at(self::KEY_1));
+
+    $box2 = new ValidStorableObject();
+    $box2->example_uint64->set(23);
+    $collection->add(Pair {self::KEY_1, $box2});
+
+    $this->assertEquals(1, $collection->count());
+    $this->assertEquals($box2, $collection->at(self::KEY_1));
+  }
+
+  public function testIsEmptyReturnsTrueWhenCollectionIsEmpty(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $this->assertTrue($collection->isEmpty());
+  }
+
+  public function testIsEmptyReturnsFalseWhenCollectionIsNotEmpty(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $collection->set(self::KEY_1, new ValidStorableObject());
+
+    $this->assertFalse($collection->isEmpty());
+  }
+
+  public function testCountReturnsExpectedValue(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $collection->set(self::KEY_1, new ValidStorableObject());
+
+    $this->assertEquals(1, $collection->count());
+
+    $collection->set(self::KEY_2, new ValidStorableObject());
+
+    $this->assertEquals(2, $collection->count());
+  }
+
+  public function testIteratorWithAllItemsIsReturned(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $collection->set(self::KEY_1, new ValidStorableObject())
+      ->set(self::KEY_2, new ValidStorableObject())
+      ->set(self::KEY_3, new ValidStorableObject());
+
+    $items = $collection->items();
+
+    $cur = 0;
+    foreach ($items as $key => $entry) {
+      ++$cur;
+      $this->assertEquals("key".$cur, $key);
+    }
+
+    $this->assertEquals(3, $cur);
+  }
+
+  public function testClearRemovesAllItems(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $collection->set(self::KEY_1, new ValidStorableObject());
+    $collection->clear();
+
+    $this->assertEquals(0, $collection->count());
+  }
+
+  public function testAddAllInsertsItemsFromArray(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $array = array(
+      Pair {self::KEY_1, new ValidStorableObject()},
+      Pair {self::KEY_2, new ValidStorableObject()},
+    );
+    $collection->addAll($array);
+    $this->assertEquals(2, $collection->count());
+  }
+
+  public function testAtReturnsExpectedValue(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $box = new ValidStorableObject();
+    $box->example_uint64->set(456);
+    $collection->set(self::KEY_1, $box);
+    $box = $collection->at(self::KEY_1);
+    $this->assertEquals(456, $box->example_uint64->get());
+  }
+
+  public function testAtThrowsExceptionWhenOutOfBounds(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $this->expectException(OutOfBoundsException::class);
+    $foo = $collection->at(self::KEY_1);
+  }
+
+  public function testSetAllOverridesAllItems(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $box = new ValidStorableObject();
+    $box->example_uint64->set(12);
+    $collection->set(self::KEY_1, $box)->set(self::KEY_2, $box);
+
+    $array = array(
+      self::KEY_1 => new ValidStorableObject(),
+      self::KEY_2 => new ValidStorableObject(),
+    );
+    $collection->setAll($array);
+
+    $this->assertEquals(2, $collection->count());
+
+    $this->assertEquals($array[self::KEY_1], $collection->at(self::KEY_1));
+    $this->assertEquals($array[self::KEY_2], $collection->at(self::KEY_2));
+  }
+
+  public function testItemIsRemovedWithRemove(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $collection->set(self::KEY_1, new ValidStorableObject())
+      ->set(self::KEY_2, new ValidStorableObject());
+
+    $this->assertEquals(2, $collection->count());
+    $this->assertNotNull($collection->get(self::KEY_1));
+    $this->assertNotNull($collection->get(self::KEY_2));
+
+    $collection->remove(self::KEY_1);
+    $this->assertEquals(1, $collection->count());
+    $this->assertNull($collection->get(self::KEY_1));
+    $this->assertNotNull($collection->get(self::KEY_2));
+  }
+
+  public function testItemIsRemovedWithRemoveKey(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $collection->set(self::KEY_1, new ValidStorableObject())
+      ->set(self::KEY_2, new ValidStorableObject());
+
+    $this->assertEquals(2, $collection->count());
+    $this->assertNotNull($collection->get(self::KEY_1));
+    $this->assertNotNull($collection->get(self::KEY_2));
+
+    $collection->removeKey(self::KEY_1);
+    $this->assertEquals(1, $collection->count());
+    $this->assertNull($collection->get(self::KEY_1));
+    $this->assertNotNull($collection->get(self::KEY_2));
+  }
+
+  public function testContainsKeyReturnsFalseWhenItemDoesNotExist(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $this->assertFalse($collection->containsKey(0));
+  }
+
+  public function testContainsKeyReturnsTrueWhenItemExists(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $collection->set(self::KEY_1, new ValidStorableObject());
+    $this->assertTrue($collection->containsKey(self::KEY_1));
+  }
+
+  public function testToArrayReturnsValidArray(): void {
+    $collection = new MapBase(StringBox::class);
+    $obj1 = new StringBox();
+    $obj1->set("value1");
+    $obj2 = new StringBox();
+    $obj2->set("value2");
+
+    $collection->set(self::KEY_1, $obj1)->set(self::KEY_2, $obj2);
+
+    $arr = $collection->toArray();
+
+    $this->assertEquals("value1", $arr[self::KEY_1]);
+    $this->assertEquals("value2", $arr[self::KEY_2]);
+  }
+
+  public function testFieldsReturnValidObject(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $this->assertInstanceOf(FieldsInterface::class, $collection->fields());
+  }
+
+  public function testValidImporterIsReturnedForStorableValue(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $importer = $collection->import();
+
+    $this->assertInstanceOf(StorableImporter::class, $importer);
+  }
+
+  public function testValidImporterIsReturnedForTypeValue(): void {
+    $collection = new MapBase(StringBox::class);
+    $importer = $collection->import();
+
+    $this->assertInstanceOf(BoxImporter::class, $importer);
+  }
+
+  public function testExportReturnsValueObject(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $this->assertInstanceOf(ExportInterface::class, $collection->export());
+  }
+
+  public function testRequiredCollectionReturnsTrue(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $collection->setIsRequired(true);
+    $this->assertTrue($collection->getIsRequired());
+  }
+
+  public function testRequiredIsFalseByDefault(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+
+    $this->assertFalse($collection->getIsRequired());
+  }
+
+  public function testIsDefaultIsTrueWhenNoModificationsMade(): void {
+    $collection = $this->getUnmodifiedCollection();
+
+    list($isDefault, $fields) = $collection->isDefaultValue();
+    $this->assertTrue($isDefault);
+  }
+
+  public function testUnmodifiedFieldsAreReturned(): void {
+    $collection = $this->getUnmodifiedCollection();
+    list($isDefault, $fields) = $collection->isDefaultValue();
+
+    $this->assertEquals(self::KEY_1, $fields[0]);
+  }
+
+  public function testIsDefaultIsFalseWhenModificationsMade(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $box = new ValidStorableObject();
+    $box->example_uint64->set(1234);
+    $collection->set(self::KEY_1, $box);
+
+    list($isDefault, $fields) = $collection->isDefaultValue();
+
+    $this->assertFalse($isDefault);
+  }
+
+  public function testIsDefaultReturnsExpectedValueAfterSet(): void {
+    $collection = new MapBase(ValidStorableObject::class);
+    $collection->setIsDefaultValue(false);
+
+    list($isDefault, $fields) = $collection->isDefaultValue();
+    $this->assertFalse($isDefault);
+  }
+
+  private function getUnmodifiedCollection(): Base<ValidStorableObject> {
+    $collection = new MapBase(ValidStorableObject::class);
+    $box = new ValidStorableObject();
+    $collection->add(Pair {self::KEY_1, $box});
+    return $collection;
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/Base.hh
@@ -24,11 +24,13 @@ class Base<Tv> implements ExportInterface {
         return '{}';
       }
 
-      $payload = '{';
+      $payload = '';
 
       if ($parentFieldName !== null) {
-        $payload .= json_encode($parentFieldName).':{';
+        $payload .= json_encode($parentFieldName).':';
       }
+
+      $payload .= '{';
 
       $firstValue = true;
 
@@ -70,10 +72,6 @@ class Base<Tv> implements ExportInterface {
           $firstValue = false;
         }
 
-      }
-
-      if ($parentFieldName != null) {
-        $payload .= '}';
       }
 
       $payload .= '}';

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/Base.hh
@@ -1,0 +1,127 @@
+<?hh // strict
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Exporter;
+
+use Zynga\Framework\Exception\V1\Exception;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+use Zynga\Framework\StorableObject\V1\Fields\Generic as FieldsGeneric;
+use Zynga\Framework\StorableObject\V1\Interfaces\ExportInterface;
+use Zynga\Framework\StorableObject\V1\Interfaces\StorableObjectInterface;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+
+class Base<Tv> implements ExportInterface {
+  public function __construct(private StorableMap<Tv> $object) {}
+
+  public function asJSON(
+    ?string $parentFieldName = null,
+    bool $sorted = false,
+  ): string {
+    try {
+      $map = $this->object->items();
+      if ($map->keys()->count() == 0) {
+        return '{}';
+      }
+
+      $payload = '{';
+
+      if ($parentFieldName !== null) {
+        $payload .= json_encode($parentFieldName).':{';
+      }
+
+      $firstValue = true;
+
+      $map->keys();
+      if ($sorted) {
+        ksort($map);
+      }
+
+      foreach ($map as $fieldName => $field) {
+        // We can skip the value if the item is still in default state.
+        list($isRequired, $isDefaultValue) =
+          FieldsGeneric::getIsRequiredAndIsDefaultValue($field);
+
+        if ($isDefaultValue === true) {
+          continue;
+        }
+
+        $value = null;
+
+        if ($field instanceof TypeInterface) {
+          $value = json_encode($field->get());
+        } else if ($field instanceof StorableObjectInterface) {
+          try {
+            $value = $field->export()->asJSON(null, $sorted);
+          } catch (Exception $e) {
+            throw $e;
+          }
+        }
+
+        if ($value !== null) {
+
+          if ($firstValue === false) {
+            $payload .= ',';
+          }
+
+          $payload .= json_encode($fieldName).':';
+          $payload .= $value;
+
+          $firstValue = false;
+        }
+
+      }
+
+      if ($parentFieldName != null) {
+        $payload .= '}';
+      }
+
+      $payload .= '}';
+
+      return $payload;
+
+    } catch (Exception $e) {
+      throw $e;
+    }
+  }
+
+  public function asMap(): Map<string, mixed> {
+
+    try {
+
+      $map = $this->object->items();
+
+      $payload = Map {};
+
+      if ($map->count() == 0) {
+        return $payload;
+      }
+
+      foreach ($map as $fieldName => $field) {
+
+        $value = null;
+
+        if ($field instanceof TypeInterface) {
+          $value = $field->get();
+        } else if ($field instanceof StorableObjectInterface) {
+          $value = $field->export()->asMap();
+        }
+
+        if ($value !== null) {
+          $payload[$fieldName] = $value;
+        }
+
+      }
+
+      return $payload;
+
+    } catch (Exception $e) {
+      throw $e;
+    }
+
+  }
+
+  public function asBinary(): string {
+    throw new OperationNotSupportedException(__METHOD__.' not supported');
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/BaseTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/BaseTest.hh
@@ -3,6 +3,9 @@
 namespace Zynga\Framework\StorableObject\Collections\Map\V2\Exporter;
 
 use Zynga\Framework\Exception\V1\Exception;
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested\MapDepth1 as DeeplyNestedMap
+;
 use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StorableObjectMap;
 use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StringBoxMap;
 use Zynga\Framework\StorableObject\V1\Exceptions\NoFieldsFoundException;
@@ -46,6 +49,15 @@ class BaseTest extends TestCase {
 
     $this->assertEquals(
       StorableObjectMap::getKeyedJsonForNestedMap(),
+      $collection->export()->asJSON(),
+    );
+  }
+
+  public function testExportAsJsonSucceedsForDeeplyNestedMap(): void {
+    $collection = DeeplyNestedMap::getPopulatedCollectionForNestedMap();
+
+    $this->assertEquals(
+      DeeplyNestedMap::getJsonForNestedMap(),
       $collection->export()->asJSON(),
     );
   }

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/BaseTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Exporter/BaseTest.hh
@@ -1,0 +1,111 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Exporter;
+
+use Zynga\Framework\Exception\V1\Exception;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StorableObjectMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StringBoxMap;
+use Zynga\Framework\StorableObject\V1\Exceptions\NoFieldsFoundException;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+use Zynga\Framework\Type\V1\StringBox;
+
+class BaseTest extends TestCase {
+  public function testExportAsJsonSucceedsForStringVector(): void {
+    $collection = StringBoxMap::getPopulatedCollectionFromVector();
+
+    $this->assertEquals(
+      StringBoxMap::getKeyedJsonForVector(),
+      $collection->export()->asJSON(),
+    );
+  }
+
+  public function testExportAsJsonSucceedsForStringMap(): void {
+    $collection = StringBoxMap::getPopulatedCollectionFromMap();
+
+    $this->assertEquals(
+      StringBoxMap::getJsonForMap(),
+      $collection->export()->asJSON(),
+    );
+  }
+
+  public function testExportAsJsonSucceedsForNestedVector(): void {
+    $collection = StorableObjectMap::getPopulatedCollectionForNestedVector();
+
+    $this->assertEquals(
+      StorableObjectMap::getKeyedJsonForNestedVector(),
+      $collection->export()->asJSON(),
+    );
+  }
+
+  public function testExportAsJsonSucceedsForNestedMap(): void {
+    $collection = StorableObjectMap::getPopulatedCollectionForNestedMap();
+
+    $this->assertEquals(
+      StorableObjectMap::getKeyedJsonForNestedMap(),
+      $collection->export()->asJSON(),
+    );
+  }
+
+  public function testExportAsJsonAddsParentKey(): void {
+    $collection = StorableObjectMap::getPopulatedCollectionForNestedMap();
+    $this->assertEquals(
+      StorableObjectMap::getKeyedJsonForNestedMap("parent"),
+      $collection->export()->asJSON("parent"),
+    );
+  }
+
+  public function testExportAsJsonSortsKeys(): void {
+    $collection = StringBoxMap::getPopulatedCollectionFromMap();
+
+    $this->assertEquals(
+      StringBoxMap::getJsonForSortedMap(),
+      $collection->export()->asJSON(null, true),
+    );
+  }
+
+  public function testExportAsJsonSucceedsForEmptyMap(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+
+    $this->assertEquals('{}', $collection->export()->asJSON());
+  }
+
+  public function testExportAsJsonThrowsExceptionForBrokenExporter(): void {
+    $collection = StorableObjectMap::getCollectionWithBrokenExporter();
+
+    $this->expectException(Exception::class);
+    $collection->export()->asJSON();
+  }
+
+  public function testExportAsBinaryThrowsNotSupportedException(): void {
+    $collection = StorableObjectMap::getPopulatedCollectionForNestedMap();
+
+    $this->expectException(OperationNotSupportedException::class);
+    $collection->export()->asBinary();
+  }
+
+  public function testExportAsMapSucceedsForStringMap(): void {
+    $collection = StringBoxMap::getPopulatedCollectionFromMap();
+
+    $this->assertEquals(
+      StringBoxMap::getRawMap(),
+      $collection->export()->asMap(),
+    );
+  }
+
+  public function testExportAsMapSucceedsForEmptyMap(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+
+    $this->assertEquals(Map {}, $collection->export()->asMap());
+  }
+
+  public function testExportAsMapThrowsExceptionForBrokenExporter(): void {
+    $collection = StorableObjectMap::getCollectionWithBrokenExporter();
+
+    $this->expectException(Exception::class);
+    $collection->export()->asMap();
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Base.hh
@@ -1,0 +1,78 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+use Zynga\Framework\StorableObject\V1\Interfaces\ImportInterface;
+
+abstract class Base<Tv> implements ImportInterface {
+  public function __construct(
+    protected StorableMap<Tv> $collection,
+    protected string $valueType,
+  ) {}
+
+  public function fromVector(Vector<mixed> $data): bool {
+    $this->collection->clear();
+
+    $keys = $data->keys();
+
+    foreach ($keys as $key) {
+      $item = $data->at($key);
+      $storable = $this->getTypeFromItem($item);
+      $this->collection->set(strval($key), $storable);
+    }
+
+    return true;
+  }
+
+  public function fromMap(Map<string, mixed> $data): bool {
+    $this->collection->clear();
+
+    foreach ($data as $key => $item) {
+      $storable = $this->getTypeFromItem($item);
+      $this->collection->set($key, $storable);
+    }
+
+    return true;
+  }
+
+  public function fromJSON(string $payload): bool {
+    $decodedJson = json_decode($payload, true);
+
+    if (is_array($decodedJson) === false) {
+      throw new UnsupportedTypeException(
+        'Payload is not valid JSON. payload='.$payload,
+      );
+    }
+
+    if ($this->isArrayKeyValuePair($decodedJson)) {
+      $this->fromMap(new Map($decodedJson));
+    } else {
+      $this->fromVector(new Vector($decodedJson));
+    }
+
+    return true;
+  }
+
+  public function fromBinary(string $payload): bool {
+    throw new OperationNotSupportedException(
+      'method='.__METHOD__.' not supported',
+    );
+  }
+
+  protected function isArrayKeyValuePair(array<mixed> $array): bool {
+    return array_values($array) !== $array;
+  }
+
+  /**
+   * Factory method for the value item the storableMap encapsulates.
+   * This should return the item type with the deserialized payload.
+   * @param $item Unknown type that must be deserialized
+   */
+  abstract protected function getTypeFromItem(mixed $item): Tv;
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Box.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Box.hh
@@ -1,0 +1,29 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
+
+use Zynga\Framework\Dynamic\V1\DynamicClassCreation;
+use Zynga\Framework\Exception\V1\Exception;
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+
+/**
+ * Class for type collection importers. This class creates object of
+ * the valueType the storableMap has specified.
+ */
+class Box<Tv> extends Base<Tv> {
+  protected function getTypeFromItem(mixed $item): Tv {
+    $type = DynamicClassCreation::createClassByNameGeneric(
+      $this->valueType,
+      Vector {},
+    );
+
+    try {
+      $type->set($item);
+      return $type;
+    } catch (Exception $e) {
+      $exception = new UnsupportedTypeException();
+      $exception->setPrevious($e);
+      throw $exception;
+    }
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/BoxTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/BoxTest.hh
@@ -4,7 +4,9 @@ namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
 
 use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\FloatBoxMap;
 use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StringBoxMap;
-use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\UnixTimestampBoxMap;
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Mock\UnixTimestampBoxMap
+;
 use
   Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
 ;

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/BoxTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/BoxTest.hh
@@ -1,0 +1,124 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\FloatBoxMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StringBoxMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\UnixTimestampBoxMap;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+class BoxTest extends TestCase {
+  public function testImportFromVectorSucceedsForString(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+    $vector = StringBoxMap::getRawVector();
+    $collection->import()->fromVector($vector);
+
+    $this->assertEquals(
+      StringBoxMap::getPopulatedCollectionFromVector(),
+      $collection,
+    );
+  }
+
+  public function testImportFromVectorSucceedsForUnixTimestamp(): void {
+    $collection = UnixTimestampBoxMap::getEmptyCollection();
+    $vector = UnixTimestampBoxMap::getRawVector();
+    $collection->import()->fromVector($vector);
+
+    $this->assertEquals(
+      UnixTimestampBoxMap::getPopulatedCollectionFromVector(),
+      $collection,
+    );
+  }
+
+  public function testImportFromVectorSucceedsForFloat(): void {
+    $collection = FloatBoxMap::getEmptyCollection();
+    $vector = FloatBoxMap::getRawVector();
+    $collection->import()->fromVector($vector);
+
+    $this->assertEquals(
+      FloatBoxMap::getPopulatedCollectionFromVector(),
+      $collection,
+    );
+  }
+
+  public function testImportFromVectorSucceedsForEmpty(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+    $collection->import()->fromVector(Vector {});
+
+    $this->assertEquals(StringBoxMap::getEmptyCollection(), $collection);
+  }
+
+  public function testImportFromVectorThrowsExceptionForInvalidType(): void {
+    $collection = UnixTimestampBoxMap::getEmptyCollection();
+    $vector = FloatBoxMap::getRawVector();
+
+    $this->expectException(UnsupportedTypeException::class);
+    $collection->import()->fromVector($vector);
+  }
+
+  public function testImportFromMapSucceedsForString(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+    $map = StringBoxMap::getRawMap();
+    $collection->import()->fromMap($map);
+
+    $this->assertEquals(
+      StringBoxMap::getPopulatedCollectionFromMap(),
+      $collection,
+    );
+  }
+
+  public function testImportFromMapSucceedsForEmpty(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+    $collection->import()->fromMap(Map {});
+
+    $this->assertEquals(StringBoxMap::getEmptyCollection(), $collection);
+  }
+
+  public function testImportFromMapThrowsExceptionForInvalidType(): void {
+    $collection = UnixTimestampBoxMap::getEmptyCollection();
+    $map = StringBoxMap::getRawMap();
+
+    $this->expectException(UnsupportedTypeException::class);
+    $collection->import()->fromMap($map);
+  }
+
+  public function testImportFromBinaryThrowsNotSupportedException(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+
+    $this->expectException(OperationNotSupportedException::class);
+    $collection->import()->fromBinary('asdas');
+  }
+
+  public function testImportFromJSONSucceedsForStringVector(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+    $json = StringBoxMap::getJsonForVector();
+    $collection->import()->fromJSON($json);
+
+    $this->assertEquals(
+      StringBoxMap::getPopulatedCollectionFromVector(),
+      $collection,
+    );
+  }
+
+  public function testImportFromJSONSucceedsForStringMap(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+    $json = StringBoxMap::getJsonForMap();
+    $collection->import()->fromJSON($json);
+
+    $this->assertEquals(
+      StringBoxMap::getPopulatedCollectionFromMap(),
+      $collection,
+    );
+  }
+
+  public function testImportFromJSONThrowExceptionForInvalidJSON(): void {
+    $collection = StringBoxMap::getEmptyCollection();
+
+    $this->expectException(UnsupportedTypeException::class);
+    $collection->import()->fromJSON('InvalidJson');
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Storable.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Storable.hh
@@ -1,0 +1,46 @@
+<?hh // strict
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
+
+use Zynga\Framework\Dynamic\V1\DynamicClassCreation;
+use Zynga\Framework\Exception\V1\Exception;
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+
+/**
+ * Class for collection importers. This class creates object of the
+ * valueType the storableMap has specified. Since valueType is of 
+ * storable nature we expect the payload to be a key value pairs to
+ * be deserialize.
+ */
+class Storable<Tv> extends Base<Tv> {
+  protected function getTypeFromItem(mixed $item): Tv {
+
+    $storable = DynamicClassCreation::createClassByNameGeneric(
+      $this->valueType,
+      Vector {},
+    );
+
+    if (is_array($item)) {
+      if ($this->isArrayKeyValuePair($item)) {
+        $storable->import()->fromMap(new Map($item));
+      } else {
+        $storable->import()->fromVector(new Vector($item));
+      }
+
+      return $storable;
+    }
+
+    if ($item instanceof Vector) {
+      $storable->import()->fromVector($item);
+      return $storable;
+    }
+
+    if ($item instanceof Map) {
+      $storable->import()->fromMap($item);
+      return $storable;
+    }
+
+    throw new UnsupportedTypeException(
+      'Unable to import item. item='.json_encode($item),
+    );
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Storable.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/Storable.hh
@@ -7,7 +7,7 @@ use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
 
 /**
  * Class for collection importers. This class creates object of the
- * valueType the storableMap has specified. Since valueType is of 
+ * valueType the storableMap has specified. Since valueType is of
  * storable nature we expect the payload to be a key value pairs to
  * be deserialize.
  */

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/StorableTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/StorableTest.hh
@@ -1,0 +1,85 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StorableObjectMap;
+use
+  Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
+;
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+class StorableTest extends TestCase {
+
+  public function testImportFromVectorSucceedsForNestedVector(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+    $vector = StorableObjectMap::getRawNestedVector();
+    $collection->import()->fromVector($vector);
+
+    $this->assertEquals(
+      StorableObjectMap::getPopulatedCollectionForNestedVector(),
+      $collection,
+    );
+  }
+
+  public function testImportFromVectorThrowsExceptionForInvalidData(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+
+    $this->expectException(UnsupportedTypeException::class);
+    $collection->import()->fromVector(Vector {"stringInsteadOfVector"});
+  }
+
+  public function testImportFromMapSucceedsForNestedMap(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+    $map = StorableObjectMap::getRawNestedMap();
+    $collection->import()->fromMap($map);
+
+    $this->assertEquals(
+      StorableObjectMap::getPopulatedCollectionForNestedMap(),
+      $collection,
+    );
+  }
+
+  public function testImportFromMapThrowsExceptionForInvalidData(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+
+    $this->expectException(UnsupportedTypeException::class);
+    $collection->import()->fromMap(Map {"key" => "stringInsteadOfMap"});
+  }
+
+  public function testImportFromBinaryThrowsNotSupportedException(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+
+    $this->expectException(OperationNotSupportedException::class);
+    $collection->import()->fromBinary('asdas');
+  }
+
+  public function testImportFromJSONSucceedsForNestedVector(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+    $json = StorableObjectMap::getJsonForNestedVector();
+    $collection->import()->fromJSON($json);
+
+    $this->assertEquals(
+      StorableObjectMap::getPopulatedCollectionForNestedVector(),
+      $collection,
+    );
+  }
+
+  public function testImportFromJSONSucceedsForNestedMap(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+    $json = StorableObjectMap::getJsonForNestedMap();
+    $collection->import()->fromJSON($json);
+
+    $this->assertEquals(
+      StorableObjectMap::getPopulatedCollectionForNestedMap(),
+      $collection,
+    );
+  }
+
+  public function testImportFromJSONThrowExceptionForInvalidJSON(): void {
+    $collection = StorableObjectMap::getEmptyCollection();
+
+    $this->expectException(UnsupportedTypeException::class);
+    $collection->import()->fromJSON('InvalidJson');
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/StorableTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Importer/StorableTest.hh
@@ -2,6 +2,9 @@
 
 namespace Zynga\Framework\StorableObject\Collections\Map\V2\Importer;
 
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested\MapDepth1 as DeeplyNestedMap
+;
 use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\StorableObjectMap;
 use
   Zynga\Framework\StorableObject\V1\Exceptions\OperationNotSupportedException
@@ -36,6 +39,17 @@ class StorableTest extends TestCase {
 
     $this->assertEquals(
       StorableObjectMap::getPopulatedCollectionForNestedMap(),
+      $collection,
+    );
+  }
+
+  public function testImportFromMapSucceedsForDeeplyNestedMap(): void {
+    $collection = DeeplyNestedMap::getEmptyCollection();
+    $map = DeeplyNestedMap::getRawNestedMap();
+    $collection->import()->fromMap($map);
+
+    $this->assertEquals(
+      DeeplyNestedMap::getPopulatedCollectionForNestedMap(),
       $collection,
     );
   }

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/ConstKeys.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/ConstKeys.hh
@@ -1,0 +1,31 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
+
+class ConstKeys {
+  const string INDEXED_KEY_0 = "0";
+  const string INDEXED_KEY_1 = "1";
+  const string INDEXED_KEY_2 = "2";
+  const string INDEXED_KEY_3 = "3";
+
+  const string STRING_KEY_0 = "key0";
+  const string STRING_KEY_1 = "key1";
+  const string STRING_KEY_2 = "key2";
+
+  const string STRING_VAL_0 = "val0";
+  const string STRING_VAL_1 = "val1";
+  const string STRING_VAL_2 = "val2";
+
+  const float FLOAT_VAL_0 = 0.123456789;
+  const float FLOAT_VAL_1 = -20.0;
+  const float FLOAT_VAL_2 = 99.99;
+
+  const int UNIX_TS_VAL_0 = 1539172800;
+  const int UNIX_TS_VAL_1 = 0;
+  const int UNIX_TS_VAL_2 = 1111111111;
+  const int UNIX_TS_VAL_3 = 999;
+
+  const int UINT_VAL_0 = 1539172800;
+  const int UINT_VAL_1 = 999;
+  const int UINT_VAL_2 = 0;
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/FloatBoxMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/FloatBoxMap.hh
@@ -19,13 +19,18 @@ class FloatBoxMap {
     $this->floatMap = new StorableMap(FloatBox::class);
   }
 
-  public static function getEmptyCollection(): StorableMapCollection<FloatBox> {
+  public static function getEmptyCollection(
+  ): StorableMapCollection<FloatBox> {
     $obj = new FloatBoxMap();
     return $obj->floatMap;
   }
 
   public static function getRawVector(): Vector<mixed> {
-    return Vector {ConstKeys::FLOAT_VAL_0, ConstKeys::FLOAT_VAL_1, ConstKeys::FLOAT_VAL_2};
+    return Vector {
+      ConstKeys::FLOAT_VAL_0,
+      ConstKeys::FLOAT_VAL_1,
+      ConstKeys::FLOAT_VAL_2,
+    };
   }
 
   public static function getPopulatedCollectionFromVector(

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/FloatBoxMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/FloatBoxMap.hh
@@ -1,0 +1,48 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\ConstKeys;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use Zynga\Framework\Type\V1\FloatBox;
+
+class FloatBoxMap {
+  /**
+   * To test functionality on Map of FloatBox type
+   */
+  public StorableMapCollection<FloatBox> $floatMap;
+
+  public function __construct() {
+    $this->floatMap = new StorableMap(FloatBox::class);
+  }
+
+  public static function getEmptyCollection(): StorableMapCollection<FloatBox> {
+    $obj = new FloatBoxMap();
+    return $obj->floatMap;
+  }
+
+  public static function getRawVector(): Vector<mixed> {
+    return Vector {ConstKeys::FLOAT_VAL_0, ConstKeys::FLOAT_VAL_1, ConstKeys::FLOAT_VAL_2};
+  }
+
+  public static function getPopulatedCollectionFromVector(
+  ): StorableMapCollection<FloatBox> {
+    $expected = new StorableMap(FloatBox::class);
+
+    $valBox0 = new FloatBox();
+    $valBox1 = new FloatBox();
+    $valBox2 = new FloatBox();
+
+    $valBox0->set(ConstKeys::FLOAT_VAL_0);
+    $valBox1->set(ConstKeys::FLOAT_VAL_1);
+    $valBox2->set(ConstKeys::FLOAT_VAL_2);
+
+    return
+      $expected->set(ConstKeys::INDEXED_KEY_0, $valBox0)
+        ->set(ConstKeys::INDEXED_KEY_1, $valBox1)
+        ->set(ConstKeys::INDEXED_KEY_2, $valBox2);
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/MapDepth1.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/MapDepth1.hh
@@ -1,0 +1,169 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested;
+
+use
+  Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested\StorableObjectDepth2
+;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\ConstKeys;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use
+  Zynga\Framework\StorableObject\Collections\Vector\V1\Base as StorableVector
+;
+use
+  Zynga\Framework\StorableObject\V1\Test\Mock\Broken\ValidButBrokenExporter
+;
+use Zynga\Framework\StorableObject\V1\Test\Mock\Valid as TestStorableObject;
+use Zynga\Framework\Type\V1\BoolBox;
+use Zynga\Framework\Type\V1\FloatBox;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+use Zynga\Framework\Type\V1\StringBox;
+use Zynga\Framework\Type\V1\UInt64Box;
+
+class MapDepth1 {
+  /**
+   * Collection of deeply nested StorableObject type
+   * testMap (Depth 1)
+   * |
+   * |-Map of StorableObject (Depth 2)
+   *   |
+   *   |- BoolVector (Depth 3)
+   *   |  |
+   *   |  |- Vector of BoolBox (Depth 4)
+   *   |
+   *   |- StorableObject (Depth 3)
+   *      |
+   *      |- StringMap (Depth 4)
+   *      |  |
+   *      |  |- Map of StringBox (Depth 5)
+   *      |
+   *      |- StorableMap (Depth 4)
+   *         |
+   *         |- Map of StorableObject (Depth 5)
+   *            |
+   *            |- StorableObject (Depth 6)
+   *               |
+   *               |- StringBox (Depth 7)
+   *               |- UInt64Box (Depth 7)
+   *               |- FloatBox  (Depth 7)
+   *
+   */
+  public StorableMapCollection<StorableObjectDepth2> $testMap;
+
+  public function __construct() {
+    $this->testMap = new StorableMap(StorableObjectDepth2::class);
+  }
+
+  /**
+   * Helper functions for vector related data
+   */
+  public static function getEmptyCollection(
+  ): StorableMapCollection<StorableObjectDepth2> {
+    $obj = new MapDepth1();
+    return $obj->testMap;
+  }
+
+  public static function getRawNestedMap(): Map<string, mixed> {
+    return new Map(self::getRawNestedArray());
+  }
+
+  private static function getRawNestedArray(): array<string, mixed> {
+    return array(
+      ConstKeys::STRING_KEY_0 =>
+        array(
+          'boolVectorDepth3' =>
+            array(true, false),
+          'storableObjectDepth3' =>
+            array(
+              'storableMapDepth4' =>
+                Map {
+                  ConstKeys::STRING_KEY_0 =>
+                    array(
+                      'storableObjectDepth6' =>
+                        array(
+                          StorableObjectDepth6::EXAMPLE_STRING_KEY =>
+                            ConstKeys::STRING_VAL_0,
+                          StorableObjectDepth6::EXAMPLE_UINT64_KEY =>
+                            ConstKeys::UINT_VAL_0,
+                          StorableObjectDepth6::EXAMPLE_FLOAT_KEY =>
+                            ConstKeys::FLOAT_VAL_0,
+                        ),
+                    ),
+                  ConstKeys::STRING_KEY_1 =>
+                    array(
+                      'storableObjectDepth6' =>
+                        array(
+                          StorableObjectDepth6::EXAMPLE_STRING_KEY =>
+                            ConstKeys::STRING_VAL_1,
+                          StorableObjectDepth6::EXAMPLE_UINT64_KEY =>
+                            ConstKeys::UINT_VAL_1,
+                          StorableObjectDepth6::EXAMPLE_FLOAT_KEY =>
+                            ConstKeys::FLOAT_VAL_1,
+                        ),
+                    ),
+                },
+              'stringMapDepth4' =>
+                array(ConstKeys::STRING_KEY_2 => ConstKeys::STRING_VAL_0),
+            ),
+        ),
+    );
+  }
+
+  public static function getPopulatedCollectionForNestedMap(
+  ): StorableMapCollection<StorableObjectDepth2> {
+    $depth5Obj0 = new StorableObjectDepth5();
+    $depth5Obj0->storableObjectDepth6
+      ->example_string
+      ->set(ConstKeys::STRING_VAL_0);
+    $depth5Obj0->storableObjectDepth6
+      ->example_uint64
+      ->set(ConstKeys::UINT_VAL_0);
+    $depth5Obj0->storableObjectDepth6
+      ->example_float
+      ->set(ConstKeys::FLOAT_VAL_0);
+
+    $depth5Obj1 = new StorableObjectDepth5();
+    $depth5Obj1->storableObjectDepth6
+      ->example_string
+      ->set(ConstKeys::STRING_VAL_1);
+    $depth5Obj1->storableObjectDepth6
+      ->example_uint64
+      ->set(ConstKeys::UINT_VAL_1);
+    $depth5Obj1->storableObjectDepth6
+      ->example_float
+      ->set(ConstKeys::FLOAT_VAL_1);
+
+    $stringBox0 = new StringBox();
+    $stringBox0->set(ConstKeys::STRING_VAL_0);
+
+    $boolBox0 = new BoolBox();
+    $boolBox0->set(true);
+
+    $boolBox1 = new BoolBox();
+    $boolBox1->set(false);
+
+    $depth2Obj = new StorableObjectDepth2();
+    $depth2Obj->storableObjectDepth3
+      ->storableMapDepth4
+      ->set(ConstKeys::STRING_KEY_0, $depth5Obj0)
+      ->set(ConstKeys::STRING_KEY_1, $depth5Obj1);
+
+    $depth2Obj->storableObjectDepth3
+      ->stringMapDepth4
+      ->set(ConstKeys::STRING_KEY_2, $stringBox0);
+
+    $depth2Obj->boolVectorDepth3->add($boolBox0)->add($boolBox1);
+
+    $expected = new StorableMap(StorableObjectDepth2::class);
+
+    return $expected->set(ConstKeys::STRING_KEY_0, $depth2Obj);
+  }
+
+  public static function getJsonForNestedMap(): string {
+    return json_encode(self::getRawNestedArray());
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth2.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth2.hh
@@ -1,0 +1,27 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested;
+
+use
+  Zynga\Framework\StorableObject\Collections\V1\Interfaces\StorableCollection as StorableVectorCollection
+;
+use Zynga\Framework\StorableObject\V1\Base as StorableObject;
+use
+  Zynga\Framework\StorableObject\Collections\Vector\V1\Base as StorableVector
+;
+use Zynga\Framework\Type\V1\BoolBox;
+
+class StorableObjectDepth2 extends StorableObject {
+  public StorableVectorCollection<BoolBox> $boolVectorDepth3;
+  public StorableObjectDepth3 $storableObjectDepth3;
+
+  public function __construct() {
+    parent::__construct();
+
+    $this->boolVectorDepth3 = new StorableVector(BoolBox::class);
+    $this->boolVectorDepth3->setIsRequired(true);
+
+    $this->storableObjectDepth3 = new StorableObjectDepth3();
+    $this->storableObjectDepth3->setIsRequired(true);
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth3.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth3.hh
@@ -1,0 +1,25 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use Zynga\Framework\StorableObject\V1\Base as StorableObject;
+use Zynga\Framework\Type\V1\StringBox;
+
+class StorableObjectDepth3 extends StorableObject {
+  public StorableMapCollection<StorableObjectDepth5> $storableMapDepth4;
+  public StorableMapCollection<StringBox> $stringMapDepth4;
+
+  public function __construct() {
+    parent::__construct();
+
+    $this->storableMapDepth4 = new StorableMap(StorableObjectDepth5::class);
+    $this->storableMapDepth4->setIsRequired(true);
+
+    $this->stringMapDepth4 = new StorableMap(StringBox::class);
+    $this->stringMapDepth4->setIsRequired(true);
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth5.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth5.hh
@@ -1,0 +1,16 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested;
+
+use Zynga\Framework\StorableObject\V1\Base as StorableObject;
+
+class StorableObjectDepth5 extends StorableObject {
+  public StorableObjectDepth6 $storableObjectDepth6;
+
+  public function __construct() {
+    parent::__construct();
+
+    $this->storableObjectDepth6 = new StorableObjectDepth6();
+    $this->storableObjectDepth6->setIsRequired(true);
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth6.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/Nested/StorableObjectDepth6.hh
@@ -1,0 +1,7 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock\Nested;
+
+use Zynga\Framework\StorableObject\V1\Test\Mock\Valid as TestStorableObject;
+
+class StorableObjectDepth6 extends TestStorableObject {}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StorableObjectMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StorableObjectMap.hh
@@ -37,7 +37,11 @@ class StorableObjectMap {
 
   public static function getRawNestedVector(): Vector<mixed> {
     return Vector {
-      Vector {ConstKeys::STRING_VAL_0, ConstKeys::UINT_VAL_0, ConstKeys::FLOAT_VAL_0},
+      Vector {
+        ConstKeys::STRING_VAL_0,
+        ConstKeys::UINT_VAL_0,
+        ConstKeys::FLOAT_VAL_0,
+      },
       Map {
         TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
         TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
@@ -79,7 +83,11 @@ class StorableObjectMap {
 
   public static function getJsonForNestedVector(): string {
     $arr = array(
-      array(ConstKeys::STRING_VAL_0, ConstKeys::UINT_VAL_0, ConstKeys::FLOAT_VAL_0),
+      array(
+        ConstKeys::STRING_VAL_0,
+        ConstKeys::UINT_VAL_0,
+        ConstKeys::FLOAT_VAL_0,
+      ),
       array(
         TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
         TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
@@ -198,12 +206,13 @@ class StorableObjectMap {
       ),
     );
 
-    $arr = $dataArr;
+    $jsonString = json_encode($dataArr, JSON_FORCE_OBJECT);
+
     if ($parent != '') {
-      $arr = array($parent => $dataArr);
+      $jsonString = '"'.$parent.'":'.$jsonString;
     }
 
-    return json_encode($arr, JSON_FORCE_OBJECT);
+    return $jsonString;
   }
 
   /**

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StorableObjectMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StorableObjectMap.hh
@@ -1,0 +1,224 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\ConstKeys;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use
+  Zynga\Framework\StorableObject\V1\Test\Mock\Broken\ValidButBrokenExporter
+;
+use Zynga\Framework\StorableObject\V1\Test\Mock\Valid as TestStorableObject;
+use Zynga\Framework\Type\V1\FloatBox;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+use Zynga\Framework\Type\V1\StringBox;
+use Zynga\Framework\Type\V1\UInt64Box;
+
+class StorableObjectMap {
+  /**
+   * Collection of StorableObject type
+   */
+  public StorableMapCollection<TestStorableObject> $testMap;
+
+  public function __construct() {
+    $this->testMap = new StorableMap(TestStorableObject::class);
+  }
+
+  /**
+   * Helper functions for vector related data
+   */
+  public static function getEmptyCollection(
+  ): StorableMapCollection<TestStorableObject> {
+    $obj = new StorableObjectMap();
+    return $obj->testMap;
+  }
+
+  public static function getRawNestedVector(): Vector<mixed> {
+    return Vector {
+      Vector {ConstKeys::STRING_VAL_0, ConstKeys::UINT_VAL_0, ConstKeys::FLOAT_VAL_0},
+      Map {
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_1,
+      },
+      array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_2,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_2,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_2,
+      ),
+    };
+  }
+
+  public static function getPopulatedCollectionForNestedVector(
+  ): StorableMapCollection<TestStorableObject> {
+    $expected = new StorableMap(TestStorableObject::class);
+
+    $testObj0 = new TestStorableObject();
+    $testObj1 = new TestStorableObject();
+    $testObj2 = new TestStorableObject();
+
+    $testObj0->example_string->set(ConstKeys::STRING_VAL_0);
+    $testObj0->example_uint64->set(ConstKeys::UINT_VAL_0);
+    $testObj0->example_float->set(ConstKeys::FLOAT_VAL_0);
+
+    $testObj1->example_string->set(ConstKeys::STRING_VAL_1);
+    $testObj1->example_uint64->set(ConstKeys::UINT_VAL_1);
+    $testObj1->example_float->set(ConstKeys::FLOAT_VAL_1);
+
+    $testObj2->example_string->set(ConstKeys::STRING_VAL_2);
+    $testObj2->example_uint64->set(ConstKeys::UINT_VAL_2);
+    $testObj2->example_float->set(ConstKeys::FLOAT_VAL_2);
+
+    return
+      $expected->set(ConstKeys::INDEXED_KEY_0, $testObj0)
+        ->set(ConstKeys::INDEXED_KEY_1, $testObj1)
+        ->set(ConstKeys::INDEXED_KEY_2, $testObj2);
+  }
+
+  public static function getJsonForNestedVector(): string {
+    $arr = array(
+      array(ConstKeys::STRING_VAL_0, ConstKeys::UINT_VAL_0, ConstKeys::FLOAT_VAL_0),
+      array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_1,
+      ),
+      array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_2,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_2,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_2,
+      ),
+    );
+
+    return json_encode($arr);
+  }
+
+  public static function getKeyedJsonForNestedVector(): string {
+    $arr = array(
+      ConstKeys::INDEXED_KEY_0 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_0,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_0,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_0,
+      ),
+      ConstKeys::INDEXED_KEY_1 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_1,
+      ),
+      ConstKeys::INDEXED_KEY_2 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_2,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_2,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_2,
+      ),
+    );
+
+    return json_encode($arr, JSON_FORCE_OBJECT);
+  }
+
+  /**
+   * Helper functions for Map related data
+   */
+  public static function getRawNestedMap(): Map<string, mixed> {
+    $vector = self::getRawNestedVector();
+    return Map {
+      ConstKeys::STRING_KEY_0 => $vector->at(0),
+      ConstKeys::STRING_KEY_1 => $vector->at(1),
+      ConstKeys::STRING_KEY_2 => $vector->at(2),
+    };
+  }
+
+  public static function getPopulatedCollectionForNestedMap(
+  ): StorableMapCollection<TestStorableObject> {
+    $expected = new StorableMap(TestStorableObject::class);
+
+    $testObj0 = new TestStorableObject();
+    $testObj1 = new TestStorableObject();
+    $testObj2 = new TestStorableObject();
+
+    $testObj0->example_string->set(ConstKeys::STRING_VAL_0);
+    $testObj0->example_uint64->set(ConstKeys::UINT_VAL_0);
+    $testObj0->example_float->set(ConstKeys::FLOAT_VAL_0);
+
+    $testObj1->example_string->set(ConstKeys::STRING_VAL_1);
+    $testObj1->example_uint64->set(ConstKeys::UINT_VAL_1);
+    $testObj1->example_float->set(ConstKeys::FLOAT_VAL_1);
+
+    $testObj2->example_string->set(ConstKeys::STRING_VAL_2);
+    $testObj2->example_uint64->set(ConstKeys::UINT_VAL_2);
+    $testObj2->example_float->set(ConstKeys::FLOAT_VAL_2);
+
+    return
+      $expected->set(ConstKeys::STRING_KEY_0, $testObj0)
+        ->set(ConstKeys::STRING_KEY_1, $testObj1)
+        ->set(ConstKeys::STRING_KEY_2, $testObj2);
+  }
+
+  public static function getJsonForNestedMap(): string {
+    $arr = array(
+      ConstKeys::STRING_KEY_0 => array(
+        ConstKeys::STRING_VAL_0,
+        ConstKeys::UINT_VAL_0,
+        ConstKeys::FLOAT_VAL_0,
+      ),
+      ConstKeys::STRING_KEY_1 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_1,
+      ),
+      ConstKeys::STRING_KEY_2 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_2,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_2,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_2,
+      ),
+    );
+
+    return json_encode($arr);
+  }
+
+  public static function getKeyedJsonForNestedMap(
+    string $parent = '',
+  ): string {
+    $dataArr = array(
+      ConstKeys::STRING_KEY_0 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_0,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_0,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_0,
+      ),
+      ConstKeys::STRING_KEY_1 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_1,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_1,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_1,
+      ),
+      ConstKeys::STRING_KEY_2 => array(
+        TestStorableObject::EXAMPLE_STRING_KEY => ConstKeys::STRING_VAL_2,
+        TestStorableObject::EXAMPLE_UINT64_KEY => ConstKeys::UINT_VAL_2,
+        TestStorableObject::EXAMPLE_FLOAT_KEY => ConstKeys::FLOAT_VAL_2,
+      ),
+    );
+
+    $arr = $dataArr;
+    if ($parent != '') {
+      $arr = array($parent => $dataArr);
+    }
+
+    return json_encode($arr, JSON_FORCE_OBJECT);
+  }
+
+  /**
+   * Helper function for collection with broken exporter
+   */
+  public static function getCollectionWithBrokenExporter(
+  ): StorableMapCollection<ValidButBrokenExporter> {
+    $obj = new ValidButBrokenExporter();
+    $obj->example_string->set(ConstKeys::STRING_VAL_0);
+    $obj->example_uint64->set(ConstKeys::UINT_VAL_0);
+    $obj->example_float->set(ConstKeys::FLOAT_VAL_0);
+
+    $collection = new StorableMap(ValidButBrokenExporter::class);
+    $collection->set(ConstKeys::STRING_KEY_0, $obj);
+
+    return $collection;
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StringBoxMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StringBoxMap.hh
@@ -1,0 +1,106 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\ConstKeys;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use Zynga\Framework\Type\V1\StringBox;
+
+class StringBoxMap {
+  /**
+   * To test functionality on Map of StringBox type
+   */
+  public StorableMapCollection<StringBox> $stringMap;
+
+  public function __construct() {
+    $this->stringMap = new StorableMap(StringBox::class);
+  }
+
+  public static function getEmptyCollection(
+  ): StorableMapCollection<StringBox> {
+    $obj = new StringBoxMap();
+    return $obj->stringMap;
+  }
+
+  /**
+   * Helper functions for vector of strings
+   */ 
+  public static function getRawVector(): Vector<mixed> {
+    return Vector {ConstKeys::STRING_VAL_0, ConstKeys::STRING_VAL_1};
+  }
+
+  public static function getPopulatedCollectionFromVector(
+  ): StorableMapCollection<StringBox> {
+    $expected = new StorableMap(StringBox::class);
+
+    $valBox0 = new StringBox();
+    $valBox1 = new StringBox();
+
+    $valBox0->set(ConstKeys::STRING_VAL_0);
+    $valBox1->set(ConstKeys::STRING_VAL_1);
+
+    return
+      $expected->set(ConstKeys::INDEXED_KEY_0, $valBox0)
+        ->set(ConstKeys::INDEXED_KEY_1, $valBox1);
+  }
+
+  public static function getJsonForVector(): string {
+    $arr = array(ConstKeys::STRING_VAL_0, ConstKeys::STRING_VAL_1);
+    return json_encode($arr);
+  }
+
+  public static function getKeyedJsonForVector(): string {
+    $arr = array(
+      ConstKeys::INDEXED_KEY_0 => ConstKeys::STRING_VAL_0,
+      ConstKeys::INDEXED_KEY_1 => ConstKeys::STRING_VAL_1,
+    );
+
+    return json_encode($arr, JSON_FORCE_OBJECT);
+  }
+
+  /**
+   * Helper functions for Map of strings
+   */
+  public static function getRawMap(): Map<string, mixed> {
+    return Map {
+      ConstKeys::STRING_KEY_1 => ConstKeys::STRING_VAL_1,
+      ConstKeys::STRING_KEY_0 => ConstKeys::STRING_VAL_0,
+    };
+  }
+
+  public static function getPopulatedCollectionFromMap(
+  ): StorableMapCollection<StringBox> {
+    $expected = new StorableMap(StringBox::class);
+
+    $valBox0 = new StringBox();
+    $valBox1 = new StringBox();
+
+    $valBox0->set(ConstKeys::STRING_VAL_0);
+    $valBox1->set(ConstKeys::STRING_VAL_1);
+
+    return
+      $expected->set(ConstKeys::STRING_KEY_1, $valBox1)
+        ->set(ConstKeys::STRING_KEY_0, $valBox0);
+  }
+
+  public static function getJsonForMap(): string {
+    $arr = array(
+      ConstKeys::STRING_KEY_1 => ConstKeys::STRING_VAL_1,
+      ConstKeys::STRING_KEY_0 => ConstKeys::STRING_VAL_0,
+    );
+
+    return json_encode($arr);
+  }
+
+  public static function getJsonForSortedMap(): string {
+    $arr = array(
+      ConstKeys::STRING_KEY_0 => ConstKeys::STRING_VAL_0,
+      ConstKeys::STRING_KEY_1 => ConstKeys::STRING_VAL_1,
+    );
+
+    return json_encode($arr);
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StringBoxMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/StringBoxMap.hh
@@ -27,7 +27,7 @@ class StringBoxMap {
 
   /**
    * Helper functions for vector of strings
-   */ 
+   */
   public static function getRawVector(): Vector<mixed> {
     return Vector {ConstKeys::STRING_VAL_0, ConstKeys::STRING_VAL_1};
   }

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnixTimestampBoxMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnixTimestampBoxMap.hh
@@ -1,0 +1,57 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
+
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Mock\ConstKeys;
+use
+  Zynga\Framework\StorableObject\Collections\V2\Interfaces\StorableMapCollection
+;
+use Zynga\Framework\Type\V1\UnixTimestampBox;
+
+class UnixTimestampBoxMap {
+  /**
+   * To test functionality on Map of UnitTimestampBox type 
+   */
+  public StorableMapCollection<UnixTimestampBox> $unixTimestampMap;
+
+  public function __construct() {
+    $this->unixTimestampMap = new StorableMap(UnixTimestampBox::class);
+  }
+
+  public static function getEmptyCollection(
+  ): StorableMapCollection<UnixTimestampBox> {
+    $obj = new UnixTimestampBoxMap();
+    return $obj->unixTimestampMap;
+  }
+
+  public static function getRawVector(): Vector<mixed> {
+    return Vector {
+      ConstKeys::UNIX_TS_VAL_0,
+      ConstKeys::UNIX_TS_VAL_1,
+      ConstKeys::UNIX_TS_VAL_2,
+      ConstKeys::UNIX_TS_VAL_3,
+    };
+  }
+
+  public static function getPopulatedCollectionFromVector(
+  ): StorableMapCollection<UnixTimestampBox> {
+    $expected = new StorableMap(UnixTimestampBox::class);
+
+    $valBox0 = new UnixTimestampBox();
+    $valBox1 = new UnixTimestampBox();
+    $valBox2 = new UnixTimestampBox();
+    $valBox3 = new UnixTimestampBox();
+
+    $valBox0->set(ConstKeys::UNIX_TS_VAL_0);
+    $valBox1->set(ConstKeys::UNIX_TS_VAL_1);
+    $valBox2->set(ConstKeys::UNIX_TS_VAL_2);
+    $valBox3->set(ConstKeys::UNIX_TS_VAL_3);
+
+    return
+      $expected->set(ConstKeys::INDEXED_KEY_0, $valBox0)
+        ->set(ConstKeys::INDEXED_KEY_1, $valBox1)
+        ->set(ConstKeys::INDEXED_KEY_2, $valBox2)
+        ->set(ConstKeys::INDEXED_KEY_3, $valBox3);
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnixTimestampBoxMap.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnixTimestampBoxMap.hh
@@ -11,7 +11,7 @@ use Zynga\Framework\Type\V1\UnixTimestampBox;
 
 class UnixTimestampBoxMap {
   /**
-   * To test functionality on Map of UnitTimestampBox type 
+   * To test functionality on Map of UnitTimestampBox type
    */
   public StorableMapCollection<UnixTimestampBox> $unixTimestampMap;
 

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnsupportedType.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnsupportedType.hh
@@ -1,9 +1,0 @@
-<?hh // strict
-
-namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
-
-/**
- * UnsupportedType which is not extending from supported types:
- * StorableObjectInterface or TypeInterface.
- */
-class UnsupportedType {}

--- a/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnsupportedType.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Map/V2/Mock/UnsupportedType.hh
@@ -1,0 +1,9 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\Map\V2\Mock;
+
+/**
+ * UnsupportedType which is not extending from supported types:
+ * StorableObjectInterface or TypeInterface.
+ */
+class UnsupportedType {}

--- a/src/Zynga/Framework/StorableObject/Collections/V2/Interfaces/StorableMapCollection.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/V2/Interfaces/StorableMapCollection.hh
@@ -1,0 +1,115 @@
+<?hh //strict
+
+namespace Zynga\Framework\StorableObject\Collections\V2\Interfaces;
+
+use Zynga\Framework\StorableObject\V1\Interfaces\StorableObjectInterface;
+
+/**
+ * Do you want to create your own collection?
+ * Do you want to also support serializing/deserializing storables/boxes?
+ * Go ahead and implement this interface! Note that on purpose we do not
+ * use the provided collection interfaces from HH\*. The reason is because
+ * they are not strict mode safe on top of the language designers not intending them
+ * to be extended for anything other than intrinsics.
+ * @see https://github.com/facebook/hhvm/issues/8042#issuecomment-342976327
+ */
+interface StorableMapCollection<Tv> extends StorableObjectInterface {
+  /**
+   * Removes all items from the collection.
+   */
+  public function clear(): bool;
+
+  /**
+   * Is the collection empty?
+   *
+   * @return - Returns `true` if the collection is empty; `false`
+   *           otherswise.
+   */
+  public function isEmpty(): bool;
+
+  /**
+   * Get the number of items in the collection. Cannot be negative.
+   *
+   * @return - Returns the number of items in the collection
+   */
+  public function count(): int;
+
+  /**
+   * Get access to the items in the collection. Can be empty.
+   *
+   * @return - Returns an `Iterable` with access to all of the items in
+   *   the collection.
+   */
+  public function items(): Map<string, Tv>;
+
+  /**
+   * Add a key/value pair to the end of the collection and return itself.
+   * If the key in the Pair exists, the value associated with it is overwritten.
+   *
+   * It returns a shallow copy of the current collection, meaning changes
+   * made to the current collection will be reflected in the returned
+   * collection.
+   *
+   * @param Pair<string, Tv> $p - The pair to add.
+   *
+   * @return - A shallow copy of the updated current collection itself.
+   */
+  public function add(Pair<string, Tv> $p): this;
+
+  /**
+   * Set a value for specified key overwrting the previous value
+   * associated with the key and return the collection itself.
+   * If the key does not exist, it is created.
+   *
+   * It returns a shallow copy of the current collection, meaning changes
+   * made to the current collection will be reflected in the returned
+   * collection.
+   *
+   * @param string $k - The key to add value to.
+   * @param Tv $v - The value to add.
+   *
+   * @return - A shallow copy of the updated current collection itself.
+   */
+  public function set(string $k, Tv $v): this;
+
+  /**
+   * For every element in the provided `Traversable`, append a value into the
+   * current collection.
+   *
+   * It returns a shallow copy of the current collection, meaning changes
+   * made to the current collection will be reflected in the returned
+   * collection.
+   *
+   * @param $traversable - The `Traversable` with the new values to set. If
+   *                       `null` is provided, no changes are made.
+   *
+   * @return - A shallow copy of the current collection with the added the
+   *           values.
+   */
+  public function addAll(?Traversable<Pair<string, Tv>> $iterable): this;
+
+  /**
+   * Remove a key and its associated value and return the collection itself.
+   *
+   * It returns a shallow copy of the current collection, meaning changes
+   * made to the current collection will be reflected in the returned
+   * collection.
+   *
+   * @param string $k - The to be removed.
+   *
+   * @return - A shallow copy of the updated current collection itself.
+   */
+  public function remove(string $k): this;
+
+  /**
+   * If the key is not present, an exception is thrown.
+   */
+  public function at(string $key): Tv;
+
+  /**
+   * Converts collection to raw array
+   * Similar to @see https://docs.hhvm.com/hack/reference/class/HH.Map/toArray/
+   */
+  public function toArray(): array<string, Tv>;
+
+}

--- a/src/Zynga/Framework/StorableObject/Collections/V2/Interfaces/StorableMapCollection.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/V2/Interfaces/StorableMapCollection.hh
@@ -102,7 +102,16 @@ interface StorableMapCollection<Tv> extends StorableObjectInterface {
   public function remove(string $k): this;
 
   /**
-   * If the key is not present, an exception is thrown.
+   * Returns the value at the specified key in the map
+   * If the key is not present, null is returned. If you would rather
+   * have an exception thrown when a key is not present then use at()
+   */
+  public function get(string $key): ?Tv;
+
+  /**
+   * Returns the value at the specified jey in the map
+   * If the key is not present, an exception is thrown. If you don't
+   * want an exception to be thrown use get()
    */
   public function at(string $key): Tv;
 

--- a/src/Zynga/Framework/StorableObject/Collections/V2/Traits/TypeEnforcement.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/V2/Traits/TypeEnforcement.hh
@@ -1,0 +1,29 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\Collections\V2\Traits;
+
+use Zynga\Framework\StorableObject\V1\Exceptions\UnsupportedTypeException;
+use Zynga\Framework\StorableObject\V1\Interfaces\StorableObjectInterface;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+
+/**
+ * Trait to enforcement value type for Collections
+ * Collection supports value of type StorableObjectInterface or TypeInterface
+ */
+trait TypeEnforcement {
+  private function validateTypeImplementsRequiredInterface<Tv>(
+    classname<Tv> $valueType,
+  ): void {
+    $interfaces = class_implements($valueType);
+
+    if (array_key_exists(StorableObjectInterface::class, $interfaces) === false &&
+        array_key_exists(TypeInterface::class, $interfaces) === false) {
+      throw new UnsupportedTypeException(
+        'Collection only support the following types for Map values:'.
+        StorableObjectInterface::class.
+        ', '.
+        TypeInterface::class,
+      );
+    }
+  }
+}

--- a/src/Zynga/Framework/StorableObject/Collections/Vector/V1/Base.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Vector/V1/Base.hh
@@ -16,6 +16,7 @@ use Zynga\Framework\StorableObject\V1\Interfaces\ImportInterface;
 use
   Zynga\Framework\StorableObject\Collections\V1\Interfaces\StorableCollection
 ;
+use Zynga\Framework\StorableObject\Collections\V2\Traits\TypeEnforcement;
 use
   Zynga\Framework\StorableObject\Collections\Vector\V1\Exporter\Base as Exporter
 ;
@@ -36,25 +37,22 @@ use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
  * @see Zynga\Framework\StorableObject\Collections\V1\Interfaces\StorableCollection for more info
  */
 class Base<Tv> implements StorableCollection<Tv> {
+  use TypeEnforcement;
+
   private Vector<Tv> $vector;
   private bool $isRequired;
   private ?bool $isDefaultValue;
 
   public function __construct(private classname<Tv> $rawType) {
-    $interfaces = class_implements($rawType);
-    if (array_key_exists(StorableObjectInterface::class, $interfaces) === false &&
-        array_key_exists(TypeInterface::class, $interfaces) === false) {
-      throw new OperationNotSupportedException(
-        'Collection only support the following types:'.
-        StorableObjectInterface::class.
-        ', '.
-        TypeInterface::class,
-      );
-    }
-
     $this->isRequired = false;
     $this->isDefaultValue = null;
     $this->vector = Vector {};
+
+    /**
+     * Can throw UnsupportedTypeException if valueType is not of expected type
+     * @see Zynga\Framework\StorableObject\Collections\V2\Traits\TypeEnforcement
+     */
+    $this->validateTypeImplementsRequiredInterface($rawType);
   }
 
   public function isEmpty(): bool {

--- a/src/Zynga/Framework/StorableObject/Collections/Vector/V1/BaseTest.hh
+++ b/src/Zynga/Framework/StorableObject/Collections/Vector/V1/BaseTest.hh
@@ -10,6 +10,9 @@ use
 use Zynga\Framework\StorableObject\V1\Interfaces\ExportInterface;
 use Zynga\Framework\StorableObject\V1\Interfaces\FieldsInterface;
 use Zynga\Framework\StorableObject\V1\Interfaces\ImportInterface;
+use
+  Zynga\Framework\StorableObject\V1\Test\Mock\UnsupportedCollectionValueType
+;
 use Zynga\Framework\StorableObject\Collections\Vector\V1\Base as VectorBase;
 use
   Zynga\Framework\StorableObject\Collections\Vector\V1\Importer\Storable as StorableImporter
@@ -23,6 +26,11 @@ class BaseTest extends TestCase {
   public function testConstructionWithBoxSucceeds(): void {
     $collection = new VectorBase(ValidStorableObject::class);
     $this->addToAssertionCount(1);
+  }
+
+  public function testConstructionFailsForUnsupportedType(): void {
+    $this->expectException(UnsupportedTypeException::class);
+    $collection = new VectorBase(UnsupportedCollectionValueType::class);
   }
 
   public function testIsEmptyReturnsTrueWhenCollectionIsEmpty(): void {

--- a/src/Zynga/Framework/StorableObject/V1/Test/Mock/UnsupportedCollectionValueType.hh
+++ b/src/Zynga/Framework/StorableObject/V1/Test/Mock/UnsupportedCollectionValueType.hh
@@ -1,0 +1,9 @@
+<?hh // strict
+
+namespace Zynga\Framework\StorableObject\V1\Test\Mock;
+
+/**
+ * UnsupportedCollectionValueType which is not extending from supported types:
+ * StorableObjectInterface or TypeInterface.
+ */
+class UnsupportedCollectionValueType {}

--- a/src/Zynga/Framework/StorableObject/V1/Test/Mock/Valid.hh
+++ b/src/Zynga/Framework/StorableObject/V1/Test/Mock/Valid.hh
@@ -9,6 +9,9 @@ use Zynga\Framework\Type\V1\UInt64Box;
 use Zynga\Framework\Type\V1\FloatBox;
 
 class Valid extends StorableObject {
+  const string EXAMPLE_STRING_KEY = "example_string";
+  const string EXAMPLE_UINT64_KEY = "example_uint64";
+  const string EXAMPLE_FLOAT_KEY = "example_float";
 
   public StringBox $example_string;
   public UInt64Box $example_uint64;


### PR DESCRIPTION
1. V1 version of the Map does not have support for importing from raw data, with this change one can import from indexed array, associative array, vector, map and nested combination these 4 types.
2. Native HH\Map only supports int or string as key so restricting the key type to be just string for V2.
3. For strictly int key type we have StorableVector which can be used.
3. If your raw data is having keys as int, storable map still be able to import such data but accessing data from storable map still requires using string format of int key.
