### PR TITLE
Fix MockedCurlRequest not behaving as intended.

### DIFF
--- a/src/Zynga/Framework/IO/Web/V1/Curl/MockedCurlRequest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Curl/MockedCurlRequest.hh
@@ -6,9 +6,9 @@ class MockedCurlRequest implements CurlInterface {
   
   private bool $setOptionsReturn = false;
   private CurlResponsePayload $curlExecReturn;
-  private mixed $curlInfoReturn;
-  
-  public function __construct(bool $setOptionsReturn, CurlResponsePayload $curlExecReturn, mixed $curlInfoReturn) {
+  private Map<int, mixed> $curlInfoReturn;
+
+  public function __construct(bool $setOptionsReturn, CurlResponsePayload $curlExecReturn, Map<int, mixed> $curlInfoReturn) {
     $this->setOptionsReturn = $setOptionsReturn;
     $this->curlExecReturn = $curlExecReturn;
     $this->curlInfoReturn = $curlInfoReturn;
@@ -23,7 +23,7 @@ class MockedCurlRequest implements CurlInterface {
   }
 
   public function getInfo(int $optName): mixed {
-    return $this->curlInfoReturn;
+    return $this->curlInfoReturn[$optName];
   }
 
   public function close(): bool {

--- a/src/Zynga/Framework/IO/Web/V1/Manager.hh
+++ b/src/Zynga/Framework/IO/Web/V1/Manager.hh
@@ -27,8 +27,8 @@ class Manager {
   public static bool $useMockCurl = false;
   public static bool $setOptionsReturn = false;
   public static ?CurlResponsePayload $curlExecReturn;
-  public static mixed $curlInfoReturn = array();
-  
+  public static Map<int, mixed> $curlInfoReturn = Map {};
+
   /**
    * Uploads $fileName to $uploadUrl using a PUT request
    *

--- a/src/Zynga/Framework/IO/Web/V1/ManagerTest.hh
+++ b/src/Zynga/Framework/IO/Web/V1/ManagerTest.hh
@@ -94,7 +94,7 @@ class ManagerTest extends TestCase {
     if($useMock == true) {
       Manager::$setOptionsReturn = true;
       Manager::$curlExecReturn = new CurlResponsePayload(true, array('success' => true));
-      Manager::$curlInfoReturn = 200;
+      Manager::$curlInfoReturn = Map { CURLINFO_HTTP_CODE => 200 };
     }
     
     $url = new UrlBox();


### PR DESCRIPTION
 Now getInfo correctly indexes into a Map, rather than ignoring its arg.