### PR TITLE
NO-TICKET: Allow the user to set success as false in handle success

### DIFF
--- a/src/Zynga/Framework/Service/V2/Handler/Base.hh
+++ b/src/Zynga/Framework/Service/V2/Handler/Base.hh
@@ -41,9 +41,11 @@ abstract class Base implements HandlerInterface {
     }
 
     $response = $service->response();
-
-    $response->success()->set(true);
-
+    
+    if($response->success()->isDefaultValue()[0]) {
+      $response->success()->set(true);
+    }
+    
     return true;
 
   }

--- a/src/Zynga/Framework/Service/V2/Handler/HttpTest.hh
+++ b/src/Zynga/Framework/Service/V2/Handler/HttpTest.hh
@@ -215,6 +215,15 @@ class HttpTest extends TestCase {
     $this->assertTrue($obj->handleGenericSuccess());
     $this->assertTrue($svc->response()->success()->get());
   }
+  
+  public function test_handleGenericSuccessWithSuccessFalse(): void {
+    $obj = new MockHttpHandler();
+    $svc = new ValidService();
+    $svc->response()->success()->set(false);
+    $obj->setService($svc);
+    $this->assertTrue($obj->handleGenericSuccess());
+    $this->assertFalse($svc->response()->success()->get());
+  }
 
   public function test_createHttpCodeResponseFailureSetsFailureBadRequest(
   ): void {


### PR DESCRIPTION
We want to allow users to set success as false even though they are returning true in handle request. 

Next step would be to define a list of error_codes which can be serviceErrorCode_<customErrorCode> that can set by each service.

