### PR TITLE
NO-TICKET: Adding direct set and get methods for Memcache

### DIFF
--- a/src/Zynga/Framework/Cache/V2/Driver/InMemory.hh
+++ b/src/Zynga/Framework/Cache/V2/Driver/InMemory.hh
@@ -61,17 +61,15 @@ class InMemory extends DriverBase implements MemcacheDriverInterface {
     return true;
   }
 
-  /**
-   * Equivalent to directAdd for the InMemory driver because
-   * Map's set and add methods are equivalent.
-   */
   public function directSet(
     string $key,
     mixed $value,
     int $flags = 0,
     int $ttl = 0,
   ): bool {
-    return $this->directAdd($key, $value, $flags, $ttl);
+    self::$data->set($key, $value);
+    $valueSet = $this->directGet($key);
+    return $valueSet === null ? false : true;
   }
 
   public function directGet(string $key): mixed {

--- a/src/Zynga/Framework/Cache/V2/Driver/InMemoryTest.hh
+++ b/src/Zynga/Framework/Cache/V2/Driver/InMemoryTest.hh
@@ -168,36 +168,59 @@ class InMemoryTest extends TestCase {
     $this->assertFalse($cache->delete($obj));
 
   }
-  
+
   public function testClearInMemoryCacheWorks(): void {
     $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
     $this->assertTrue($cache->clearInMemoryCache());
   }
-  
+
   public function testConnect(): void {
     $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
     $this->assertTrue($cache->connect());
   }
-  
+
   public function testDirectIncrementFails(): void {
     $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
     $cache->directDelete('test');
     $this->assertEquals(0, $cache->directIncrement('test', 1));
   }
-  
+
   public function testDirectIncrementIncrements(): void {
     $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
     $cache->directAdd('test', 1);
     $this->assertEquals(2, $cache->directIncrement('test', 1));
     $this->assertTrue($cache->directDelete('test'));
   }
-  
+
   public function testDirectAddAndDeleteSucceeds(): void {
     $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
     $this->assertTrue($cache->directAdd('test', 1));
     $this->assertTrue($cache->directDelete('test'));
   }
-  
+
+  public function testDirectSetOverwritesPreviousValue(): void {
+    $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
+    $this->assertTrue($cache->directSet('test', 1));
+    $this->assertEquals(1, $cache->directGet('test'));
+    // overwrite the previous value
+    $this->assertTrue($cache->directSet('test', 2));
+    $this->assertEquals(2, $cache->directGet('test'));
+
+    $this->assertTrue($cache->directDelete('test'));
+  }
+
+  public function testDirectGetReturnsExpectedValueAfterAdd(): void {
+    $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
+    $this->assertTrue($cache->directAdd('test', 'value'));
+    $this->assertEquals('value', $cache->directGet('test'));
+    $this->assertTrue($cache->directDelete('test'));
+  }
+
+  public function testDirectGetReturnsNullForNonexistentKey(): void {
+    $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
+    $this->assertEquals(null, $cache->directGet('test'));
+  }
+
   public function testDirectDeleteFails(): void {
     $cache = CacheFactory::factory(InMemoryDriver::class, 'InMemory_Mock');
     $this->assertFalse($cache->directDelete('test'));

--- a/src/Zynga/Framework/Cache/V2/Driver/Memcache.hh
+++ b/src/Zynga/Framework/Cache/V2/Driver/Memcache.hh
@@ -103,14 +103,13 @@ class Memcache extends DriverBase {
 
   }
 
-  public function directGet(string $key, int $count = 1): array<mixed> {
+  public function directGet(string $key): mixed {
     try {
       $this->connect();
 
-      $keyArray = array($key, $count);
-      $items = $this->_memcache->get($keyArray);
+      $item = $this->_memcache->get($key);
 
-      return $items;
+      return $item;
     } catch (Exception $e) {
       throw $e;
     }
@@ -221,14 +220,14 @@ class Memcache extends DriverBase {
 
       $this->connect();
 
-      $data = $this->_memcache->get($key);
+      $data = $this->directGet($key);
 
       // no data to work with.
       if ($data === false) {
         return null;
       }
 
-      $obj->import()->fromJSON($data);
+      $obj->import()->fromJSON(strval($data));
 
       return $obj;
 
@@ -287,11 +286,6 @@ class Memcache extends DriverBase {
       throw $e;
     }
 
-  }
-
-  public function close(): bool {
-    $closed = $this->_memcache->close();
-    return $closed;
   }
 
 }

--- a/src/Zynga/Framework/Cache/V2/Driver/MemcacheTest.hh
+++ b/src/Zynga/Framework/Cache/V2/Driver/MemcacheTest.hh
@@ -45,12 +45,6 @@ class MemcacheTest extends TestCase {
 
   }
 
-  public function testClose(): void {
-    $cache = CacheFactory::factory(MemcacheDriver::class, 'Mock');
-    $this->assertTrue($cache->connect());
-    $this->assertTrue($cache->close());
-  }
-
   public function testConnect_NoServersConfigured(): void {
 
     $obj = CacheFactory::factory(
@@ -266,11 +260,9 @@ class MemcacheTest extends TestCase {
     $value = '{"test":"data"}';
 
     $this->assertTrue($cache->directSet($key, $value));
-    $cachedValueArray = $cache->directGet($key);
-    $cachedValuesAsVector = new Vector($cachedValueArray);
+    $cachedValue = $cache->directGet($key);
 
-    $this->assertCount(1, $cachedValuesAsVector);
-    $this->assertEquals($value, $cachedValuesAsVector[0]);
+    $this->assertEquals($value, $cachedValue);
   }
 
   public function testCacheAllowsKeyOverride_Fail(): void {

--- a/src/Zynga/Framework/Cache/V2/Driver/MemcacheTest.hh
+++ b/src/Zynga/Framework/Cache/V2/Driver/MemcacheTest.hh
@@ -45,6 +45,12 @@ class MemcacheTest extends TestCase {
 
   }
 
+  public function testClose(): void {
+    $cache = CacheFactory::factory(MemcacheDriver::class, 'Mock');
+    $this->assertTrue($cache->connect());
+    $this->assertTrue($cache->close());
+  }
+
   public function testConnect_NoServersConfigured(): void {
 
     $obj = CacheFactory::factory(
@@ -209,6 +215,24 @@ class MemcacheTest extends TestCase {
     $cache->directAdd('bc-test-some-key-'.mt_rand(), 'some-value-'.mt_rand());
   }
 
+  public function testErrorTrap_DirectSet(): void {
+    $cache = CacheFactory::factory(
+      MemcacheDriver::class,
+      'Mock_NoServersConfigured',
+    );
+    $this->expectException(NoServerPairsProvidedException::class);
+    $cache->directSet('test-some-key-'.mt_rand(), 'some-value-'.mt_rand());
+  }
+
+  public function testErrorTrap_DirectGet(): void {
+    $cache = CacheFactory::factory(
+      MemcacheDriver::class,
+      'Mock_NoServersConfigured',
+    );
+    $this->expectException(NoServerPairsProvidedException::class);
+    $cache->directGet('test-some-key-'.mt_rand());
+  }
+
   public function testErrorTrap_DirectDelete(): void {
     $cache = CacheFactory::factory(
       MemcacheDriver::class,
@@ -233,6 +257,20 @@ class MemcacheTest extends TestCase {
 
     $this->assertTrue($cache->directDelete($randomKey));
 
+  }
+
+  public function testDirectSetGetCycle(): void {
+    $cache = CacheFactory::factory(MemcacheDriver::class, 'Mock');
+
+    $key = 'demo';
+    $value = '{"test":"data"}';
+
+    $this->assertTrue($cache->directSet($key, $value));
+    $cachedValueArray = $cache->directGet($key);
+    $cachedValuesAsVector = new Vector($cachedValueArray);
+
+    $this->assertCount(1, $cachedValuesAsVector);
+    $this->assertEquals($value, $cachedValuesAsVector[0]);
   }
 
   public function testCacheAllowsKeyOverride_Fail(): void {

--- a/src/Zynga/Framework/Cache/V2/Interfaces/MemcacheDriverInterface.hh
+++ b/src/Zynga/Framework/Cache/V2/Interfaces/MemcacheDriverInterface.hh
@@ -4,15 +4,24 @@ namespace Zynga\Framework\Cache\V2\Interfaces;
 
 interface MemcacheDriverInterface extends DriverInterface {
   public function directIncrement(string $key, int $incrementValue = 1): int;
-    
+
   public function directAdd(
     string $key,
     mixed $value,
     int $flags = 0,
     int $ttl = 0,
   ): bool;
-  
+
   public function directDelete(string $key): bool;
-  
+
+  public function directSet(
+    string $key,
+    mixed $value,
+    int $flags = 0,
+    int $ttl = 0,
+  ): bool;
+
+  public function directGet(string $key): mixed;
+
   public function connect(): bool;
 }


### PR DESCRIPTION
Updating the Memcache driver to support direct get and set operations. Also addressed the issue of duplicate server pairings as described here: https://php.net/manual/en/memcached.addserver.php
