### PR TITLE
NO-TICKET: Fixing locks in pgdata

### DIFF
--- a/src/Zynga/Framework/Lockable/Cache/V1/Driver/Caching.hh
+++ b/src/Zynga/Framework/Lockable/Cache/V1/Driver/Caching.hh
@@ -254,9 +254,12 @@ class Caching extends FactoryDriverBase implements DriverInterface {
       //}
 
       // Release the lock as we are done here.
-      $unlockReturn = $this->unlock($obj);
-
-      return $unlockReturn;
+      $unlockSuccess = true;
+      if($releaseLockOnSet === true) {
+        $unlockSuccess = $this->unlock($obj);
+      }
+      
+      return $setSuccess || $unlockSuccess;
 
     } catch (Exception $e) {
       throw $e;

--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgModel/ReaderInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgModel/ReaderInterface.hh
@@ -12,7 +12,7 @@ interface ReaderInterface {
   public function getByPk<TModelClass as PgRowInterface>(
     classname<TModelClass> $model,
     mixed $id,
-    bool $shouldLock
+    bool $getLocked
   ): ?PgRowInterface;
   
   public function get<TModelClass as PgRowInterface>(

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryLockTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryLockTest.hh
@@ -41,17 +41,22 @@ class InventoryLockTest extends BaseInventoryTest {
       $this->assertEquals($id, $firstTrip->id->get());
       $this->assertEquals($name, $firstTrip->name->get());
       $this->validateModelStats($inventory, 0, 1, 1);
-  
+      
+      // Should already be locked now
+      $this->assertTrue($inventory->cache()->getDataCache()->isLocked($firstTrip));
+      
     } else {
       $this->fail('type returned should of been ItemType');
     }
   
-  
     // unlock your obj
     if ($firstTrip instanceof ItemType) {
       $this->assertTrue($inventory->unlockRowCache($firstTrip));
+      
+      // Should not be locked now
+      $this->assertFalse($inventory->cache()->getDataCache()->isLocked($firstTrip));
     }
-  
+    
     $this->removeCachedItem($id);
   }
   


### PR DESCRIPTION
Cleaning up lock code. fetchSingleRowFromDataCache was releasing the lock even when getByPk was asking for the lock. 