### PR TITLE
Adding bool support for Db query export

### DIFF
--- a/src/Zynga/Framework/Database/V2/Driver/GenericPDO/Quoter.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/GenericPDO/Quoter.hh
@@ -31,6 +31,13 @@ class Quoter implements QuoteInterface {
   /**
    * See @QuoteInterface
    */
+  public function boolValue(bool $value): string {
+    return sprintf('%d', (int) $value);
+  }
+
+  /**
+   * See @QuoteInterface
+   */
   public function floatValue(float $value): string {
     return sprintf('%f', $value);
   }

--- a/src/Zynga/Framework/Database/V2/Driver/GenericPDO/QuoterTest.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/GenericPDO/QuoterTest.hh
@@ -15,6 +15,14 @@ class QuoterTest extends TestCase {
     $this->assertEquals("3", $quoter->intValue(3));
   }
 
+  public function testBoolValue(): void {
+    $driver =
+      DatabaseFactory::factory(DriverInterface::class, 'Mock_Cluster');
+    $quoter = new Quoter($driver);
+    $this->assertEquals('1', $quoter->boolValue(true));
+    $this->assertEquals('0', $quoter->boolValue(false));
+  }
+
   public function testFloatValue(): void {
     $driver =
       DatabaseFactory::factory(DriverInterface::class, 'Mock_Cluster');

--- a/src/Zynga/Framework/Database/V2/Driver/Mock/Quoter.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/Mock/Quoter.hh
@@ -16,6 +16,10 @@ class Quoter implements QuoteInterface {
     return sprintf('%d', $value);
   }
 
+  public function boolValue(bool $value): string {
+    return sprintf('%d', (int) $value);
+  }
+
   public function floatValue(float $value): string {
     return sprintf('%f', $value);
   }

--- a/src/Zynga/Framework/Database/V2/Driver/Mock/QuoterTest.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/Mock/QuoterTest.hh
@@ -18,6 +18,8 @@ class QuoterTest extends TestCase {
 
     $this->assertEquals('0.000000', $quoter->floatValue(0.00));
     $this->assertEquals('123456', $quoter->intValue(123456));
+    $this->assertEquals('1', $quoter->boolValue(true));
+    $this->assertEquals('0', $quoter->boolValue(false));
     $this->assertEquals('i am teapot', $quoter->textValue('i am teapot'));
 
     $vec = Vector {};

--- a/src/Zynga/Framework/Database/V2/Driver/Vertica/Quoter.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/Vertica/Quoter.hh
@@ -16,6 +16,10 @@ class Quoter implements QuoteInterface {
     return sprintf('%d', $value);
   }
 
+  public function boolValue(bool $value): string {
+    return sprintf('%d', (int) $value);
+  }
+
   public function floatValue(float $value): string {
     return sprintf('%f', $value);
   }

--- a/src/Zynga/Framework/Database/V2/Driver/Vertica/QuoterTest.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/Vertica/QuoterTest.hh
@@ -63,6 +63,16 @@ class QuoterTest extends TestCase {
 
   }
 
+  public function testBoolValues(): void {
+
+    $driver =
+      DatabaseFactory::factory(DriverInterface::class, 'Test_Vertica');
+    $quoter = $driver->getQuoter();
+    $this->assertEquals('1', $quoter->boolValue(true));
+    $this->assertEquals('0', $quoter->boolValue(false));
+    DatabaseFactory::clear();
+  }
+
   public function testTextValues(): void {
 
     $driver =

--- a/src/Zynga/Framework/Database/V2/Interfaces/QuoteInterface.hh
+++ b/src/Zynga/Framework/Database/V2/Interfaces/QuoteInterface.hh
@@ -21,6 +21,13 @@ interface QuoteInterface {
   public function intValue(int $value): string;
 
   /**
+   * Creates a sql query safe value out of a boolean.
+   * @param bool $value
+   * @return string
+   */
+  public function boolValue(bool $value): string;
+
+  /**
    * Creates a sql query safe value out of a float
    * @param  float $value
    * @return string

--- a/src/Zynga/Framework/PgData/V1/PgModel/Db.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Db.hh
@@ -57,6 +57,8 @@ class Db implements DbInterface {
       return $dbh->quote()->floatValue($value);
     } else if (is_int($value)) {
       return $dbh->quote()->intValue($value);
+    } else if (is_bool($value)) {
+      return $dbh->quote()->boolValue($value);
     }
 
     throw new UnsupportedValueTypeException('value='.gettype($value));

--- a/src/Zynga/Framework/PgData/V1/Sharded/PgModel/Db.hh
+++ b/src/Zynga/Framework/PgData/V1/Sharded/PgModel/Db.hh
@@ -67,6 +67,8 @@ class Db implements DbInterface {
       return $dbh->quote()->floatValue($value);
     } else if (is_int($value)) {
       return $dbh->quote()->intValue($value);
+    } else if (is_bool($value)) {
+      return $dbh->quote()->boolValue($value);
     }
 
     throw new UnsupportedValueTypeException('value='.gettype($value));

--- a/src/Zynga/Framework/ShardedDatabase/V3/Config/Mysql/ConnectionBaseTest.hh
+++ b/src/Zynga/Framework/ShardedDatabase/V3/Config/Mysql/ConnectionBaseTest.hh
@@ -745,6 +745,24 @@ abstract class ConnectionBaseTest<TType as UInt64Box> extends TestCase {
 
   }
 
+  public function testBoolValues(): void {
+
+    $driver = DatabaseFactory::factory(
+      DriverInterface::class,
+      $this->getConfigName(),
+    );
+
+    $quoter = $driver->getQuoter();
+
+    $testShard = new UInt64Box(1);
+    $driver->setShardType($testShard);
+
+    $this->assertEquals('1', $quoter->boolValue(true));
+    $this->assertEquals('0', $quoter->boolValue(false));
+
+    $this->cleanDriverFromFactory();
+  }
+
   public function testTextValues(): void {
 
     $driver = DatabaseFactory::factory(

--- a/src/Zynga/Framework/ShardedDatabase/V3/Driver/GenericPDO/Quoter.hh
+++ b/src/Zynga/Framework/ShardedDatabase/V3/Driver/GenericPDO/Quoter.hh
@@ -18,6 +18,10 @@ class Quoter<TType as TypeInterface> implements QuoteInterface {
     return sprintf('%d', $value);
   }
 
+  public function boolValue(bool $value): string {
+    return sprintf('%d', (int) $value);
+  }
+
   public function floatValue(float $value): string {
     return sprintf('%f', $value);
   }

--- a/src/Zynga/Framework/ShardedDatabase/V3/Driver/Mock/Quoter.hh
+++ b/src/Zynga/Framework/ShardedDatabase/V3/Driver/Mock/Quoter.hh
@@ -17,6 +17,10 @@ class Quoter<TType as TypeInterface> implements QuoteInterface {
     return sprintf('%d', $value);
   }
 
+  public function boolValue(bool $value): string {
+    return sprintf('%d', (int) $value);
+  }
+
   public function floatValue(float $value): string {
     return sprintf('%f', $value);
   }

--- a/src/Zynga/Framework/ShardedDatabase/V3/Driver/Mock/QuoterTest.hh
+++ b/src/Zynga/Framework/ShardedDatabase/V3/Driver/Mock/QuoterTest.hh
@@ -18,6 +18,8 @@ class QuoterTest extends TestCase {
 
     $this->assertEquals('0.000000', $quoter->floatValue(0.00));
     $this->assertEquals('123456', $quoter->intValue(123456));
+    $this->assertEquals('1', $quoter->boolValue(true));
+    $this->assertEquals('0', $quoter->boolValue(false));
     $this->assertEquals('i am teapot', $quoter->textValue('i am teapot'));
 
     $vec = Vector {};


### PR DESCRIPTION
1. This functionality allows feature models to use BoolBoxes instead of UInt8Box.
2. Internally MySql uses tinyint(1) representation only. Db side not much diff but improved readability at Poker features side.