### PR TITLE
Adds Support to Allow PGData to be Unit Tested Without Disabling the Mock Cache

### DIFF
--- a/src/Zynga/Framework/Factory/V2/Base.hh
+++ b/src/Zynga/Framework/Factory/V2/Base.hh
@@ -183,6 +183,7 @@ abstract class Base implements FactoryInterface {
     string $actualClass,
     string $mockClass,
   ): void {
+    self::enableMockDrivers();
     self::$_mockOverrides[$actualClass] = $mockClass;
   }
 

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Base.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Base.hh
@@ -1,0 +1,12 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Factory\V2\Config\Base as ConfigBase;
+use Zynga\Framework\Factory\V2\Test\Interfaces\ConfigInterface;
+
+abstract class Base extends ConfigBase implements ConfigInterface {
+  public function getDriver(): string {
+    return 'Mock';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Dev.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Dev.hh
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Factory\V2\Test\Config\Mock\Base as ConfigBase;
+
+class Dev extends ConfigBase {
+  public function getExampleConfigValue(): string {
+    return 'This-is-Dev-Reader';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/DevTest.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/DevTest.hh
@@ -1,0 +1,14 @@
+<?hh //strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use Zynga\Framework\Factory\V2\Test\Config\Mock\Reader\Dev as TestConfig;
+
+class DevTest extends TestCase {
+  public function test_configValues(): void {
+    $obj = new TestConfig();
+    $this->assertEquals('This-is-Dev-Reader', $obj->getExampleConfigValue());
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Production.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Production.hh
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Factory\V2\Test\Config\Mock\Base as ConfigBase;
+
+class Production extends ConfigBase {
+  public function getExampleConfigValue(): string {
+    return 'This-is-Production-Reader';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/ProductionTest.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/ProductionTest.hh
@@ -1,0 +1,19 @@
+<?hh //strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use
+  Zynga\Framework\Factory\V2\Test\Config\Mock\Reader\Production as TestConfig
+;
+
+class ProductionTest extends TestCase {
+  public function test_configValues(): void {
+    $obj = new TestConfig();
+    $this->assertEquals(
+      'This-is-Production-Reader',
+      $obj->getExampleConfigValue(),
+    );
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Staging.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/Staging.hh
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Factory\V2\Test\Config\Mock\Base as ConfigBase;
+
+class Staging extends ConfigBase {
+  public function getExampleConfigValue(): string {
+    return 'This-is-Staging-Reader';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/StagingTest.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/Mock/Reader/StagingTest.hh
@@ -1,0 +1,17 @@
+<?hh //strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\Mock\Reader;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use Zynga\Framework\Factory\V2\Test\Config\Mock\Reader\Staging as TestConfig;
+
+class StagingTest extends TestCase {
+  public function test_configValues(): void {
+    $obj = new TestConfig();
+    $this->assertEquals(
+      'This-is-Staging-Reader',
+      $obj->getExampleConfigValue(),
+    );
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Base.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Base.hh
@@ -1,0 +1,12 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Factory\V2\Config\Base as ConfigBase;
+use Zynga\Framework\Factory\V2\Test\Interfaces\ConfigInterface;
+
+abstract class Base extends ConfigBase implements ConfigInterface {
+  public function getDriver(): string {
+    return 'Mock';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Dev.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Dev.hh
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Factory\V2\Test\Config\MockOverride\Base as ConfigBase;
+
+class Dev extends ConfigBase {
+  public function getExampleConfigValue(): string {
+    return 'This-is-overridden-Dev';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/DevTest.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/DevTest.hh
@@ -1,0 +1,17 @@
+<?hh //strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use Zynga\Framework\Factory\V2\Test\Config\MockOverride\Dev as TestConfig;
+
+class DevTest extends TestCase {
+  public function test_configValues(): void {
+    $obj = new TestConfig();
+    $this->assertEquals(
+      'This-is-overridden-Dev',
+      $obj->getExampleConfigValue(),
+    );
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Production.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Production.hh
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Factory\V2\Test\Config\MockOverride\Base as ConfigBase;
+
+class Production extends ConfigBase {
+  public function getExampleConfigValue(): string {
+    return 'This-is-overridden-Production';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/ProductionTest.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/ProductionTest.hh
@@ -1,0 +1,19 @@
+<?hh //strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use
+  Zynga\Framework\Factory\V2\Test\Config\MockOverride\Production as TestConfig
+;
+
+class ProductionTest extends TestCase {
+  public function test_configValues(): void {
+    $obj = new TestConfig();
+    $this->assertEquals(
+      'This-is-overridden-Production',
+      $obj->getExampleConfigValue(),
+    );
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Staging.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/Staging.hh
@@ -1,0 +1,11 @@
+<?hh // strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Factory\V2\Test\Config\MockOverride\Base as ConfigBase;
+
+class Staging extends ConfigBase {
+  public function getExampleConfigValue(): string {
+    return 'This-is-overridden-Staging';
+  }
+}

--- a/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/StagingTest.hh
+++ b/src/Zynga/Framework/Factory/V2/Test/Config/MockOverride/StagingTest.hh
@@ -1,0 +1,19 @@
+<?hh //strict
+
+namespace Zynga\Framework\Factory\V2\Test\Config\MockOverride;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use
+  Zynga\Framework\Factory\V2\Test\Config\MockOverride\Staging as TestConfig
+;
+
+class StagingTest extends TestCase {
+  public function test_configValues(): void {
+    $obj = new TestConfig();
+    $this->assertEquals(
+      'This-is-overridden-Staging',
+      $obj->getExampleConfigValue(),
+    );
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgModelInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgModelInterface.hh
@@ -21,8 +21,10 @@ interface PgModelInterface {
   public function getResultSetCacheName(): string;
   public function getReadDatabaseName(): string;
   public function getWriteDatabaseName(): string;
+  public function lockRowCache(PgRowInterface $row): bool;
   public function reader(): ReaderInterface;
   public function stats(): StatsInterface;
+  public function unlockRowCache(PgRowInterface $row): bool;
   public function writer(): WriterInterface;
   public function getByPk<TModelClass as PgRowInterface>(
     classname<TModelClass> $model,

--- a/src/Zynga/Framework/PgData/V1/Interfaces/Sharded/PgModelInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/Sharded/PgModelInterface.hh
@@ -7,4 +7,7 @@ use
 ;
 use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
 
-interface PgModelInterface extends PgModelInterfaceBase {}
+interface PgModelInterface extends PgModelInterfaceBase {
+  public function getShardId(): TypeInterface;
+
+}

--- a/src/Zynga/Framework/PgData/V1/PgModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModelFactory.hh
@@ -1,0 +1,26 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1;
+
+use Zynga\Framework\PgData\V1\Interfaces\PgModelInterface;
+
+abstract class PgModelFactory {
+  private static ?PgModelInterface $_mock;
+
+  public static function getModel(): PgModelInterface {
+    if (self::$_mock !== null) {
+      return self::$_mock;
+    }
+    return static::getRealModel();
+  }
+  public static function enableMock(PgModelInterface $mock): void {
+    self::$_mock = $mock;
+  }
+
+  public static function disableMock(): void {
+    self::$_mock = null;
+  }
+
+  protected abstract static function getRealModel(): PgModelInterface;
+
+}

--- a/src/Zynga/Framework/PgData/V1/PgModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModelFactory.hh
@@ -7,11 +7,11 @@ use Zynga\Framework\PgData\V1\Interfaces\PgModelInterface;
 abstract class PgModelFactory {
   private static ?PgModelInterface $_mock;
 
-  public static function getModel(): PgModelInterface {
+  public function getModel(): PgModelInterface {
     if (self::$_mock !== null) {
       return self::$_mock;
     }
-    return static::getRealModel();
+    return $this->getRealModel();
   }
   public static function enableMock(PgModelInterface $mock): void {
     self::$_mock = $mock;
@@ -21,6 +21,6 @@ abstract class PgModelFactory {
     self::$_mock = null;
   }
 
-  protected abstract static function getRealModel(): PgModelInterface;
+  protected abstract function getRealModel(): PgModelInterface;
 
 }

--- a/src/Zynga/Framework/PgData/V1/PgShardedModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/PgShardedModelFactory.hh
@@ -2,18 +2,19 @@
 
 namespace Zynga\Framework\PgData\V1;
 
-use Zynga\Framework\PgData\V1\Interfaces\PgModelInterface;
+use Zynga\Framework\PgData\V1\Interfaces\Sharded\PgModelInterface;
 use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
 
 abstract class PgShardedModelFactory {
   private static ?PgModelInterface $_mock;
 
-  public static function getModel(TypeInterface $shardKey): PgModelInterface {
+  public function getModel(): PgModelInterface {
     if (self::$_mock !== null) {
       return self::$_mock;
     }
-    return static::getRealModel($shardKey);
+    return $this->getRealModel();
   }
+
   public static function enableMock(PgModelInterface $mock): void {
     self::$_mock = $mock;
   }
@@ -22,8 +23,6 @@ abstract class PgShardedModelFactory {
     self::$_mock = null;
   }
 
-  protected abstract static function getRealModel(
-    TypeInterface $shardKey,
-  ): PgModelInterface;
+  protected abstract function getRealModel(): PgModelInterface;
 
 }

--- a/src/Zynga/Framework/PgData/V1/PgShardedModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/PgShardedModelFactory.hh
@@ -1,0 +1,29 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1;
+
+use Zynga\Framework\PgData\V1\Interfaces\PgModelInterface;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+
+abstract class PgShardedModelFactory {
+  private static ?PgModelInterface $_mock;
+
+  public static function getModel(TypeInterface $shardKey): PgModelInterface {
+    if (self::$_mock !== null) {
+      return self::$_mock;
+    }
+    return static::getRealModel($shardKey);
+  }
+  public static function enableMock(PgModelInterface $mock): void {
+    self::$_mock = $mock;
+  }
+
+  public static function disableMock(): void {
+    self::$_mock = null;
+  }
+
+  protected abstract static function getRealModel(
+    TypeInterface $shardKey,
+  ): PgModelInterface;
+
+}

--- a/src/Zynga/Framework/PgData/V1/PgShardedModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/PgShardedModelFactory.hh
@@ -8,6 +8,8 @@ use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
 abstract class PgShardedModelFactory {
   private static ?PgModelInterface $_mock;
 
+  public function __construct(private TypeInterface $_shardKey) {}
+
   public function getModel(): PgModelInterface {
     if (self::$_mock !== null) {
       return self::$_mock;

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/FactoryTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/FactoryTest.hh
@@ -1,0 +1,58 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Test\ExampleFeature\Model;
+
+use
+  Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded\ShardedInventoryFactory
+;
+use
+  Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded\ShardedInventoryModel
+;
+use Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\InventoryModel;
+use
+  Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\InventoryModelFactory
+;
+use Zynga\Framework\PgData\V1\Testing\Mock\PgModel as MockPgModel;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+use Zynga\Framework\Type\V1\UInt32Box;
+
+class FactoryTest extends TestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    ShardedInventoryFactory::disableMock();
+    InventoryModelFactory::disableMock();
+  }
+
+  public function tearDown(): void {
+    ShardedInventoryFactory::disableMock();
+    InventoryModelFactory::disableMock();
+    parent::tearDown();
+  }
+
+  public function testSettingMockReturnsSameInstanceAsTheSetMock(): void {
+    $mockShardedModel = new MockPgModel();
+    $mockModel = new MockPgModel();
+    ShardedInventoryFactory::enableMock($mockShardedModel);
+    InventoryModelFactory::enableMock($mockModel);
+
+    $this->assertSame(
+      $mockShardedModel,
+      ShardedInventoryFactory::getModel(new UInt32Box()),
+    );
+
+    $this->assertSame($mockModel, InventoryModelFactory::getModel());
+  }
+
+  public function testGettingModelsWithoutMockReturnsActaulInstancesOfTheModels(
+  ): void {
+    $this->assertInstanceOf(
+      ShardedInventoryModel::class,
+      ShardedInventoryFactory::getModel(new UInt32Box()),
+    );
+    $this->assertInstanceOf(
+      InventoryModel::class,
+      InventoryModelFactory::getModel(),
+    );
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/FactoryTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/FactoryTest.hh
@@ -13,8 +13,12 @@ use
   Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\InventoryModelFactory
 ;
 use Zynga\Framework\PgData\V1\Testing\Mock\PgModel as MockPgModel;
+use
+  Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded\ShardedInventoryModel as MockPgShardedModel
+;
+
 use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
-use Zynga\Framework\Type\V1\UInt32Box;
+use Zynga\Framework\Type\V1\UInt64Box;
 
 class FactoryTest extends TestCase {
 
@@ -31,28 +35,31 @@ class FactoryTest extends TestCase {
   }
 
   public function testSettingMockReturnsSameInstanceAsTheSetMock(): void {
-    $mockShardedModel = new MockPgModel();
+    $mockShardedModel = new MockPgShardedModel(new UInt64Box());
     $mockModel = new MockPgModel();
     ShardedInventoryFactory::enableMock($mockShardedModel);
     InventoryModelFactory::enableMock($mockModel);
 
-    $this->assertSame(
-      $mockShardedModel,
-      ShardedInventoryFactory::getModel(new UInt32Box()),
-    );
+    $sharedFactory = new ShardedInventoryFactory(new UInt64Box());
 
-    $this->assertSame($mockModel, InventoryModelFactory::getModel());
+    $this->assertSame($mockShardedModel, $sharedFactory->getModel());
+
+    $nonShardedFactory = new InventoryModelFactory();
+    $this->assertSame($mockModel, $nonShardedFactory->getModel());
   }
 
   public function testGettingModelsWithoutMockReturnsActaulInstancesOfTheModels(
   ): void {
+    $sharedFactory = new ShardedInventoryFactory(new UInt64Box());
+    $nonShardedFactory = new InventoryModelFactory();
+
     $this->assertInstanceOf(
       ShardedInventoryModel::class,
-      ShardedInventoryFactory::getModel(new UInt32Box()),
+      $sharedFactory->getModel(),
     );
     $this->assertInstanceOf(
       InventoryModel::class,
-      InventoryModelFactory::getModel(),
+      $nonShardedFactory->getModel(),
     );
   }
 }

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryModelFactory.hh
@@ -1,0 +1,13 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Test\ExampleFeature\Model;
+
+use Zynga\Framework\PgData\V1\Interfaces\PgModelInterface;
+use Zynga\Framework\PgData\V1\PgModelFactory;
+use Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\InventoryModel;
+
+class InventoryModelFactory extends PgModelFactory {
+  protected static function getRealModel(): PgModelInterface {
+    return new InventoryModel();
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryModelFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryModelFactory.hh
@@ -7,7 +7,7 @@ use Zynga\Framework\PgData\V1\PgModelFactory;
 use Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\InventoryModel;
 
 class InventoryModelFactory extends PgModelFactory {
-  protected static function getRealModel(): PgModelInterface {
+  protected function getRealModel(): InventoryModel {
     return new InventoryModel();
   }
 }

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryFactory.hh
@@ -7,12 +7,13 @@ use Zynga\Framework\PgData\V1\PgShardedModelFactory;
 use
   Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded\ShardedInventoryModel
 ;
-use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+use Zynga\Framework\Type\V1\UInt64Box;
 
 class ShardedInventoryFactory extends PgShardedModelFactory {
-  protected static function getRealModel(
-    TypeInterface $shardKey,
-  ): PgModelInterface {
-    return new ShardedInventoryModel($shardKey);
+
+  public function __construct(private UInt64Box $_shardKey) {}
+
+  protected function getRealModel(): ShardedInventoryModel {
+    return new ShardedInventoryModel($this->_shardKey);
   }
 }

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryFactory.hh
@@ -11,7 +11,9 @@ use Zynga\Framework\Type\V1\UInt64Box;
 
 class ShardedInventoryFactory extends PgShardedModelFactory {
 
-  public function __construct(private UInt64Box $_shardKey) {}
+  public function __construct(private UInt64Box $_shardKey) {
+    parent::__construct($_shardKey);
+  }
 
   protected function getRealModel(): ShardedInventoryModel {
     return new ShardedInventoryModel($this->_shardKey);

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryFactory.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryFactory.hh
@@ -1,0 +1,18 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded;
+
+use Zynga\Framework\PgData\V1\Interfaces\PgModelInterface;
+use Zynga\Framework\PgData\V1\PgShardedModelFactory;
+use
+  Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded\ShardedInventoryModel
+;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+
+class ShardedInventoryFactory extends PgShardedModelFactory {
+  protected static function getRealModel(
+    TypeInterface $shardKey,
+  ): PgModelInterface {
+    return new ShardedInventoryModel($shardKey);
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryModel.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryModel.hh
@@ -2,6 +2,7 @@
 
 namespace Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded;
 
+use Zynga\Framework\PgData\V1\Interfaces\Sharded\PgModelInterface;
 use Zynga\Framework\PgData\V1\Sharded\PgModel;
 use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
 use Zynga\Framework\Type\v1\UInt64Box;

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryModel.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/Sharded/ShardedInventoryModel.hh
@@ -1,6 +1,6 @@
 <?hh // strict
 
-namespace Zynga\Framework\PgData\V1\Test\ExampleFeature\ModelSharded;
+namespace Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Sharded;
 
 use Zynga\Framework\PgData\V1\Sharded\PgModel;
 use Zynga\Framework\Type\V1\Interfaces\TypeInterface;

--- a/src/Zynga/Framework/PgData/V1/Testing/BasePgDataTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/BasePgDataTest.hh
@@ -12,6 +12,11 @@ use Zynga\Framework\Lockable\Cache\V1\Factory as LockableCacheFactory;
 use Zynga\Framework\ShardedDatabase\V3\Driver\Mock as MockShardedDriver;
 use Zynga\Framework\ShardedDatabase\V3\Factory as ShardedDatabaseFactory;
 
+/**
+ * Base Test class for tests that have to interact with PGData and mock databases.
+ * This test file will configure the Factories to override the default PGData drivers
+ * to use their mock counterparts.
+ */
 abstract class BasePgDataTest extends TestCase {
 
   <<__Override>>

--- a/src/Zynga/Framework/PgData/V1/Testing/BasePgDataTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/BasePgDataTest.hh
@@ -1,0 +1,96 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Testing;
+
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use Zynga\Framework\Cache\V2\Driver\InMemory;
+use Zynga\Framework\Cache\V2\Factory as CacheFactory;
+use Zynga\Framework\Database\V2\Factory as DatabaseFactory;
+use Zynga\Framework\Database\V2\Driver\Mock as MockDriver;
+use Zynga\Framework\Lockable\Cache\V1\Factory as LockableCacheFactory;
+use Zynga\Framework\ShardedDatabase\V3\Driver\Mock as MockShardedDriver;
+use Zynga\Framework\ShardedDatabase\V3\Factory as ShardedDatabaseFactory;
+
+abstract class BasePgDataTest extends TestCase {
+
+  <<__Override>>
+  public function setUp(): void {
+    parent::setUp();
+    CacheFactory::enableMockDrivers();
+    LockableCacheFactory::enableMockDrivers();
+    LockableCacheFactory::overrideMockDriver(
+      'PgResultSet',
+      'Mock\PgResultSet',
+    );
+    LockableCacheFactory::overrideMockDriver('PgData', 'Mock\PgData');
+
+    DatabaseFactory::enableMockDrivers();
+    DatabaseFactory::clear();
+    ShardedDatabaseFactory::enableMockDrivers();
+    ShardedDatabaseFactory::clear();
+    $this->clearPGDataCaches();
+  }
+
+  <<__Override>>
+  public function tearDown(): void {
+    $this->clearPGDataCaches();
+    LockableCacheFactory::disableMockDrivers();
+    DatabaseFactory::clear();
+    DatabaseFactory::disableMockDrivers();
+    ShardedDatabaseFactory::clear();
+    ShardedDatabaseFactory::disableMockDrivers();
+    parent::tearDown();
+  }
+
+  protected function addEmptyResultSetToNonShardedDatabase(): void {
+    $driver = DatabaseFactory::factory(MockDriver::class, 'Mock');
+    $driver->addEmptyResultSet();
+  }
+
+  /**
+   * @param string $file the name of the file to load, the suffix .data will be appended
+   */
+  protected function addResultSetsToNonShardedDatabaseFromFile(
+    string $className,
+    string $file,
+  ): void {
+    $this->assertTrue(
+      DatabaseFactory::loadResultsForTest($className, $file),
+      'Failed to load result sets',
+    );
+  }
+
+  protected function addEmptyResultSetToShardedDatabase(): void {
+    $driver =
+      ShardedDatabaseFactory::factory(MockShardedDriver::class, 'Mock');
+    $driver->addEmptyResultSet();
+  }
+
+  /**
+   * @param string $file the name of the file to load, the suffix _UserSharded.data will be appended
+   */
+  protected function addResultSetsToShardedDatabaseFromFile(
+    string $className,
+    string $file,
+  ): void {
+    $this->assertTrue(
+      ShardedDatabaseFactory::loadResultsForTest($className, $file),
+      'Failed to load result sets',
+    );
+  }
+
+  private function clearPGDataCaches(): void {
+    $cacheDriver =
+      CacheFactory::factory(InMemory::class, 'Mock\InMemory\PgResultSet');
+    $cacheDriver->clearInMemoryCache();
+
+    $cacheDriver = CacheFactory::factory(
+      InMemory::class,
+      'Mock\InMemory\PgResultSetLocks',
+    );
+    $cacheDriver->clearInMemoryCache();
+
+    LockableCacheFactory::clear();
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgModel.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgModel.hh
@@ -1,0 +1,46 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Testing\Mock;
+
+use Zynga\Framework\PgData\V1\Interfaces\PgModel\ReaderInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgModel\StatsInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgModel\WriterInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgRowInterface;
+use Zynga\Framework\PgData\V1\Testing\Mock\PgReaderWriter;
+use Zynga\Framework\PgData\V1\PgModel as Base;
+
+class PgModel extends Base {
+  private PgReaderWriter $_readerWriter;
+
+  public function __construct() {
+    $this->_readerWriter = new PgReaderWriter();
+  }
+
+  public function getMockReaderWriter(): PgReaderWriter {
+    return $this->_readerWriter;
+  }
+
+  public function getDataCacheName(): string {
+    return 'Mock\PgData';
+  }
+
+  public function getResultSetCacheName(): string {
+    return 'Mock\PgResultSet';
+  }
+
+  public function getReadDatabaseName(): string {
+    return 'Mock';
+  }
+
+  public function getWriteDatabaseName(): string {
+    return 'Mock';
+  }
+
+  public function createReaderObject(): ReaderInterface {
+    return $this->_readerWriter;
+  }
+
+  public function createWriterObject(): WriterInterface {
+    return $this->_readerWriter;
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgModel.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgModel.hh
@@ -9,6 +9,10 @@ use Zynga\Framework\PgData\V1\Interfaces\PgRowInterface;
 use Zynga\Framework\PgData\V1\Testing\Mock\PgReaderWriter;
 use Zynga\Framework\PgData\V1\PgModel as Base;
 
+/**
+ * A Mock PGModel which uses the PGReaderWriter instead of direct interactions with
+ *  the database.
+ */
 class PgModel extends Base {
   private PgReaderWriter $_readerWriter;
 
@@ -20,18 +24,22 @@ class PgModel extends Base {
     return $this->_readerWriter;
   }
 
+  // Driver is not used, since class using PgReaderWriter
   public function getDataCacheName(): string {
     return 'Mock\PgData';
   }
 
+  // Driver is not used, since class using PgReaderWriter
   public function getResultSetCacheName(): string {
     return 'Mock\PgResultSet';
   }
 
+  // Driver is not used, since class using PgReaderWriter
   public function getReadDatabaseName(): string {
     return 'Mock';
   }
 
+  // Driver is not used, since class using PgReaderWriter
   public function getWriteDatabaseName(): string {
     return 'Mock';
   }

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgModelsTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgModelsTest.hh
@@ -1,0 +1,30 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Testing\Mock;
+
+use Zynga\Framework\PgData\V1\Testing\Mock\PgModel as MockPgModel;
+use
+  Zynga\Framework\PgData\V1\Testing\Mock\PgShardedModel as MockPgModelShard
+;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+use Zynga\Framework\Type\V1\UInt64Box;
+
+class PgModelsTest extends TestCase {
+  public function testPgModelMocksDriverNames(): void {
+    $model = new MockPgModel();
+    $this->assertEquals('Mock\PgData', $model->getDataCacheName());
+    $this->assertEquals('Mock\PgResultSet', $model->getResultSetCacheName());
+    $this->assertEquals('Mock', $model->getReadDatabaseName());
+    $this->assertEquals('Mock', $model->getWriteDatabaseName());
+  }
+
+  public function testShardedPgModelMocksDriverNames(): void {
+    $id = new UInt64Box(4);
+    $model = new MockPgModelShard($id);
+    $this->assertEquals('Mock\PgData', $model->getDataCacheName());
+    $this->assertEquals('Mock\PgResultSet', $model->getResultSetCacheName());
+    $this->assertEquals('Mock', $model->getReadDatabaseName());
+    $this->assertEquals('Mock', $model->getWriteDatabaseName());
+    $this->assertEquals($id->get(), $model->getShardId()->get());
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriter.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriter.hh
@@ -1,0 +1,156 @@
+<?hh // strict
+
+namespace Zynga\Framework\PgData\V1\Testing\Mock;
+
+use Zynga\Framework\PgData\V1\Exceptions\UnsupportedOperandException;
+use Zynga\Framework\PgData\V1\Interfaces\PgModel\ReaderInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgModel\WriterInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgResultSetInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgRowInterface;
+use Zynga\Framework\PgData\V1\Interfaces\PgWhereClauseInterface;
+use Zynga\Framework\PgData\V1\PgCachedResultSet;
+use Zynga\Framework\PgData\V1\PgResultSet;
+use Zynga\Framework\PgData\V1\PgWhereClause;
+use Zynga\Framework\PgData\V1\PgWhereOperand;
+use Zynga\Framework\PgData\V1\PgWhereOperand\PgPragma;
+use Zynga\Framework\PgData\V1\PgWhereOperand\PgPragmaType;
+use Zynga\Framework\StorableObject\Collections\Map\V2\Base as StorableMap;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+use Zynga\Framework\Type\V1\UInt64Box;
+
+/**
+ * A implementation of PgData's Reader & Writer interfaces that keeps everything in memory for unit testing.
+ */
+class PgReaderWriter implements ReaderInterface, WriterInterface {
+
+  public bool $addSucceeds = true;
+  public bool $saveSucceeds = true;
+
+  private StorableMap<StorableMap<PgRowInterface>> $tables;
+
+  public function __construct() {
+    $this->tables = new StorableMap(StorableMap::class);
+  }
+
+  public function getByPk<TModelClass as PgRowInterface>(
+    classname<TModelClass> $model,
+    mixed $id,
+    bool $getLocked,
+  ): ?PgRowInterface {
+    $table = $this->getTable($model);
+    $key = (string) $id;
+    return $table->get($key);
+  }
+
+  public function get<TModelClass as PgRowInterface>(
+    classname<TModelClass> $model,
+    ?PgWhereClauseInterface $where = null,
+  ): PgResultSetInterface<PgRowInterface> {
+    $table = $this->getTable($model);
+    $resultSet = new PgResultSet($model);
+    foreach ($table->toArray() as $row) {
+      if (self::matchesWhere($row, $where)) {
+        $resultSet->add($row);
+      }
+    }
+    return $resultSet;
+  }
+
+  public function createCachedResultSet<TModelClass as PgRowInterface>(
+    classname<TModelClass> $model,
+    PgWhereClauseInterface $pgWhere,
+  ): PgCachedResultSet<TypeInterface> {
+    return new PgCachedResultSet(UInt64Box::class, $pgWhere, $model);
+  }
+
+  public function getTable(string $tableName): StorableMap<PgRowInterface> {
+    $table = $this->tables->get($tableName);
+    if ($table === null) {
+      $table = new StorableMap(PgRowInterface::class);
+      $this->tables->set($tableName, $table);
+    }
+    return $table;
+  }
+
+  public function add(PgRowInterface $row, bool $shouldUnlock = true): bool {
+    if ($this->addSucceeds) {
+      $table = $this->getTable(get_class($row));
+      $key = $row->getPrimaryKeyTyped();
+
+      // Set PK on new rows
+      if ($key->get() === 0) {
+        $key->set($table->count() + 1);
+      }
+
+      $key = (string) $key;
+      $table->set($key, $row);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public function save(PgRowInterface $row, bool $shouldUnlock = true): bool {
+    if ($this->saveSucceeds) {
+      $table = $this->getTable(get_class($row));
+      $key = (string) $row->getPrimaryKeyTyped();
+      $table->set($key, $row);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public function delete(
+    PgRowInterface $row,
+    bool $shouldUnlock = true,
+  ): bool {
+    $table = $this->getTable(get_class($row));
+    $key = (string) $row->getPrimaryKeyTyped();
+    $table->remove($key);
+    return true;
+  }
+
+  protected static function matchesWhere(
+    PgRowInterface $row,
+    ?PgWhereClauseInterface $where,
+  ): bool {
+    if ($where instanceof PgWhereClause) {
+      $pragmas = $where->getPragmas();
+      foreach ($pragmas as $pragma) {
+        if ($pragma->getPragmaType() !== PgPragmaType::AND) {
+          throw new UnsupportedOperandException(
+            "Unsupported pragma type. Not yet implemented!",
+          );
+        }
+        if (self::matchesPragma($row, $pragma) === false) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      return true;
+    }
+  }
+
+  protected static function matchesPragma(
+    PgRowInterface $row,
+    PgPragma $pragma,
+  ): bool {
+    $field = $row->fields()->getTypedField($pragma->getField());
+    switch ($pragma->getOperand()) {
+      case PgWhereOperand::EQUALS:
+        return $field->get() === $pragma->getValue();
+      case PgWhereOperand::NOT_EQUALS:
+        return $field->get() !== $pragma->getValue();
+      case PgWhereOperand::GREATER_THAN:
+        return $field->get() > $pragma->getValue();
+      case PgWhereOperand::LESS_THAN:
+        return $field->get() < $pragma->getValue();
+      default:
+        throw new UnsupportedOperandException(
+          "Unsupported operand. Not yet implemented!",
+        );
+    }
+  }
+}

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriterTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriterTest.hh
@@ -1,0 +1,188 @@
+<?hh // strict
+
+namespace Zynga\Framework\PgData\V1\Testing\Mock;
+
+use Zynga\Framework\PgData\V1\Exceptions\UnsupportedOperandException;
+use Zynga\Framework\PgData\V1\Test\ExampleFeature\Model\Inventory\ItemType;
+use Zynga\Framework\PgData\V1\Testing\Mock\PgModel as MockPgModel;
+use Zynga\Framework\PgData\V1\Testing\Mock\PgReaderWriter;
+use Zynga\Framework\Testing\TestCase\V2\Base as TestCase;
+
+use Zynga\Framework\PgData\V1\PgWhereClause;
+use Zynga\Framework\PgData\V1\PgWhereOperand;
+use Zynga\Framework\Type\V1\UInt64Box;
+
+class PgUnitTestReaderWriterTest extends TestCase {
+
+  public function testPgModelMocksDriverNames(): void {
+    $model = new MockPgModel();
+    $this->assertEquals('Mock\PgData', $model->getDataCacheName());
+    $this->assertEquals('Mock\PgResultSet', $model->getResultSetCacheName());
+    $this->assertEquals('Mock', $model->getReadDatabaseName());
+    $this->assertEquals('Mock', $model->getWriteDatabaseName());
+  }
+
+  public function testAddDelete(): void {
+    $model = new MockPgModel();
+    $reader = $model->reader();
+    $writer = $model->writer();
+
+    // Define an item.
+    $item = new ItemType($model);
+    $item->id->set(1);
+    $item->name->set("cool_name");
+
+    // Ensure the item isn't present.
+    $this->assertNull(
+      $reader->getByPk(get_class($item), $item->id->get(), false),
+    );
+
+    // Add an item.
+    $writer->add($item, false);
+
+    // Ensure the item is present.
+    $this->assertNotNull(
+      $reader->getByPk(get_class($item), $item->id->get(), false),
+    );
+
+    // Delete the item.
+    $item->delete();
+
+    // Ensure the item isn't present.
+    $this->assertNull(
+      $reader->getByPk(get_class($item), $item->id->get(), false),
+    );
+  }
+
+  public function testInThrowsException(): void {
+    $model = new MockPgModel();
+    $rw = $model->getMockReaderWriter();
+
+    // Define an item.
+    $item = new ItemType($model);
+    $item->id->set(1);
+    $item->name->set("cool_name");
+
+    // Add an item.
+    $rw->add($item, false);
+
+    // Query with an IN operand.
+    $this->expectException(UnsupportedOperandException::class);
+    $where = new PgWhereClause($model);
+    $where->and('id', PgWhereOperand::IN, $item->id->get());
+    $this->assertEquals(1, $rw->get(get_class($item), $where)->count());
+  }
+
+  public function testOrThrowsException(): void {
+    $model = new MockPgModel();
+    $rw = $model->getMockReaderWriter();
+
+    // Define an item.
+    $item = new ItemType($model);
+    $item->id->set(1);
+    $item->name->set("cool_name");
+
+    // Add an item.
+    $rw->add($item, false);
+
+    // Query with an OR pragma.
+    $this->expectException(UnsupportedOperandException::class);
+    $where = new PgWhereClause($model);
+    $where->or('id', PgWhereOperand::EQUALS, $item->id->get());
+    $this->assertEquals(1, $rw->get(get_class($item), $where)->count());
+  }
+
+  public function testWhere(): void {
+    $model = new MockPgModel();
+    $rw = $model->getMockReaderWriter();
+
+    // Define an item.
+    $item = new ItemType($model);
+    $item->id->set(1);
+    $item->name->set("cool_name");
+
+    // Add an item.
+    $rw->add($item, false);
+
+    // Ensure an item is present.
+    // (null, implicit where)
+    $this->assertEquals(1, $rw->get(get_class($item))->count());
+
+    // Use other operands too.
+    $where = new PgWhereClause($model);
+    $where->and('id', PgWhereOperand::NOT_EQUALS, 2);
+    $where->and('id', PgWhereOperand::LESS_THAN, 2);
+    $where->and('id', PgWhereOperand::GREATER_THAN, 0);
+    $this->assertEquals(1, $rw->get(get_class($item), $where)->count());
+  }
+
+  public function testSavingRow(): void {
+    $model = new MockPgModel();
+    $rw = $model->getMockReaderWriter();
+
+    $item = new ItemType($model);
+    $item->id->set(1);
+    $item->name->set("cool_name");
+
+    $this->assertTrue($rw->save($item));
+    $this->assertEquals(
+      $item,
+      $rw->getByPk(ItemType::class, $item->id, false),
+    );
+
+    $item2 = new ItemType($model);
+    $item2->id->set(2);
+    $item2->name->set("cool_name_2");
+
+    $rw->saveSucceeds = false;
+    $this->assertFalse($rw->save($item2));
+    $this->assertNull($rw->getByPk(ItemType::class, $item2->id, false));
+  }
+
+  public function testAddingRow(): void {
+    $model = new MockPgModel();
+    $rw = $model->getMockReaderWriter();
+
+    $item = new ItemType($model);
+    $item->name->set("cool_name");
+
+    $this->assertTrue($rw->add($item));
+    $this->assertEquals(
+      $item,
+      $rw->getByPk(ItemType::class, new UInt64Box(1), false),
+    );
+
+    $this->assertEquals(1, $item->id->get());
+
+    $item2 = new ItemType($model);
+    $item2->name->set("cool_name");
+
+    $rw->addSucceeds = false;
+    $this->assertFalse($rw->add($item2));
+    $this->assertNull($rw->getByPk(ItemType::class, new UInt64Box(2), false));
+  }
+
+  public function testGettingRowsWithEqualsOperator(): void {
+    $model = new MockPgModel();
+    $rw = $model->getMockReaderWriter();
+
+    $item = new ItemType($model);
+    $item->id->set(1);
+    $item->name->set("cool_name");
+
+    $item2 = new ItemType($model);
+    $item2->id->set(4);
+    $item2->name->set("cool_name_2");
+
+    $rw->add($item);
+    $rw->add($item2);
+
+    $where = new PgWhereClause($model);
+    $where->and("id", PgWhereOperand::EQUALS, 4);
+    $resultSet = $rw->get(ItemType::class, $where);
+
+    $this->assertEquals(1, $resultSet->count());
+    $this->assertEquals($item2, $resultSet->at(0));
+  }
+
+}

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriterTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriterTest.hh
@@ -14,14 +14,6 @@ use Zynga\Framework\Type\V1\UInt64Box;
 
 class PgUnitTestReaderWriterTest extends TestCase {
 
-  public function testPgModelMocksDriverNames(): void {
-    $model = new MockPgModel();
-    $this->assertEquals('Mock\PgData', $model->getDataCacheName());
-    $this->assertEquals('Mock\PgResultSet', $model->getResultSetCacheName());
-    $this->assertEquals('Mock', $model->getReadDatabaseName());
-    $this->assertEquals('Mock', $model->getWriteDatabaseName());
-  }
-
   public function testAddDelete(): void {
     $model = new MockPgModel();
     $reader = $model->reader();

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgShardedModel.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgShardedModel.hh
@@ -1,0 +1,17 @@
+<?hh //strict
+
+namespace Zynga\Framework\PgData\V1\Testing\Mock;
+
+use Zynga\Framework\PgData\V1\Testing\Mock\PgModel;
+use Zynga\Framework\PgData\V1\Interfaces\Sharded\PgModelInterface;
+use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+
+class PgShardedModel extends PgModel implements PgModelInterface {
+  public function __construct(private TypeInterface $_shardId) {
+    parent::__construct();
+  }
+
+  public function getShardId(): TypeInterface {
+    return $this->_shardId;
+  }
+}


### PR DESCRIPTION
* Adds a mock implementation of the PGData Writer and Reader to allow better simulations of edge cases with PGData
* Adds Abstract Factories to allow PGData Mocks to be injected into normal code flow with less boiler plate code
* Adds the ability to override which driver is used instead of always using `Mock` when loading driver from factories
* Added base test class which configures the test environment for PGData