### PR TITLE
Updating ConnectionGoneAwayException logs to not expose credentials

### DIFF
--- a/src/Zynga/Framework/Database/V2/Driver/GenericPDO/Base.hh
+++ b/src/Zynga/Framework/Database/V2/Driver/GenericPDO/Base.hh
@@ -156,7 +156,10 @@ class Base extends BaseDriver {
       // if not connected attempt to connect.
       if ($this->_dbh === null) {
         throw new ConnectionGoneAwayException(
-          'NO_CONNECTION host='.$this->getConfig()->getConnectionString(),
+          'NO_CONNECTION host='.
+          $this->getConfig()->getCurrentServer().
+          ' schema='.
+          $this->getConfig()->getCurrentDatabase(),
         );
       }
 
@@ -187,7 +190,10 @@ class Base extends BaseDriver {
 
       if ($this->_dbh === null) {
         throw new ConnectionGoneAwayException(
-          'NO_CONNECTION host='.$this->getConfig()->getConnectionString(),
+          'NO_CONNECTION host='.
+          $this->getConfig()->getCurrentServer().
+          ' schema='.
+          $this->getConfig()->getCurrentDatabase(),
         );
       }
 


### PR DESCRIPTION
Updating the GenericPDO driver to not expose the full connection string as many features using this core code could log this exception out. Instead we only log the server and schema which should be sufficient.