### PR TITLE
Add Ability For  PGData To Add Elements To The Database Without Writing To The Cache

### DIFF
--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgModel/WriterInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgModel/WriterInterface.hh
@@ -5,7 +5,7 @@ namespace Zynga\Framework\PgData\V1\Interfaces\PgModel;
 use Zynga\Framework\PgData\V1\Interfaces\PgRowInterface;
 
 interface WriterInterface {
-  public function add(PgRowInterface $row, bool $shouldUnlock): bool;
+  public function add(PgRowInterface $row): bool;
   public function addToDbOnly(PgRowInterface $row): bool;
   public function save(PgRowInterface $row, bool $shouldUnlock): bool;
   public function delete(PgRowInterface $obj, bool $shouldUnlock): bool;

--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgModel/WriterInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgModel/WriterInterface.hh
@@ -6,6 +6,7 @@ use Zynga\Framework\PgData\V1\Interfaces\PgRowInterface;
 
 interface WriterInterface {
   public function add(PgRowInterface $row, bool $shouldUnlock): bool;
+  public function addToDbOnly(PgRowInterface $row): bool;
   public function save(PgRowInterface $row, bool $shouldUnlock): bool;
   public function delete(PgRowInterface $obj, bool $shouldUnlock): bool;
 }

--- a/src/Zynga/Framework/PgData/V1/PgModel.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel.hh
@@ -170,7 +170,7 @@ abstract class PgModel implements PgModelInterface {
 
   public function add(PgRowInterface $row, bool $shouldUnlock = true): bool {
     try {
-      return $this->writer()->add($row, $shouldUnlock);
+      return $this->writer()->add($row);
     } catch (Exception $e) {
       throw $e;
     }

--- a/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
@@ -22,9 +22,9 @@ class Writer implements WriterInterface {
   }
 
   /**
-   * Add a new item. $shouldUnlock is an unused parameter.
+   * Add a new item.
    */
-  public function add(PgRowInterface $row, bool $shouldUnlock): bool {
+  public function add(PgRowInterface $row): bool {
 
     $wasSuccessful = $this->addToDbOnly($row);
     if ($wasSuccessful) {

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriter.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriter.hh
@@ -90,6 +90,10 @@ class PgReaderWriter implements ReaderInterface, WriterInterface {
     }
   }
 
+  public function addToDbOnly(PgRowInterface $row): bool {
+    return $this->add($row, false);
+  }
+
   public function save(PgRowInterface $row, bool $shouldUnlock = true): bool {
     if ($this->saveSucceeds) {
       $table = $this->getTable(get_class($row));

--- a/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriterTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Testing/Mock/PgReaderWriterTest.hh
@@ -30,7 +30,7 @@ class PgUnitTestReaderWriterTest extends TestCase {
     );
 
     // Add an item.
-    $writer->add($item, false);
+    $writer->add($item);
 
     // Ensure the item is present.
     $this->assertNotNull(


### PR DESCRIPTION
Sometimes a developer would like to use PGData to write models to the database, but not have the records read before the keys would expire. This can cause extra pressure on the cache, for data that will not be read.

This adds the new API method `addToDbOnly` which will bypass the cache write step, but will still allow us to use PGData to write our SQL stmt, and update any internal cache keys used to generate primary keys.

This PR also removes row lock before attempting to write to the database. Since the row lock, will attempt multiple time, causing requests to wait for multiple DB requests. 