### PR TITLE
Adding support for tombstone PgData rows

### DIFF
--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
@@ -14,4 +14,6 @@ interface PgRowInterface extends StorableObjectInterface {
   public function getTableName(): string;
   public function save(bool $shouldUnlock = true): bool;
   public function delete(bool $shouldUnlock = true): bool;
+  public function setTombstone(): bool;
+  public function isTombstoned(): bool;
 }

--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
@@ -14,6 +14,6 @@ interface PgRowInterface extends StorableObjectInterface {
   public function getTableName(): string;
   public function save(bool $shouldUnlock = true): bool;
   public function delete(bool $shouldUnlock = true): bool;
-  public function setTombstone(): bool;
+  public function tombstoneRow(): bool;
   public function isTombstoned(): bool;
 }

--- a/src/Zynga/Framework/PgData/V1/PgModel/Reader.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Reader.hh
@@ -58,6 +58,12 @@ class Reader implements ReaderInterface {
 
       if ($cached instanceof PgRowInterface) {
         $pgModel->stats()->incrementCacheHits();
+
+        // if the cached row is tombstoned immediately return a null
+        if ($cached->isTombstoned() === true) {
+          return null;
+        }
+
         return $cached;
       }
 

--- a/src/Zynga/Framework/PgData/V1/PgModel/SqlGenerator.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/SqlGenerator.hh
@@ -15,6 +15,8 @@ use \Exception;
 
 class SqlGenerator {
 
+  const string SKIP_FIELD_PREFIX = '_ignore_';
+
   public static function getSelectSql(
     QueryableInterface $dbh,
     PgModelInterface $model,
@@ -35,6 +37,11 @@ class SqlGenerator {
       // 2) Build a list of fields to include on the select
       $selectFields = Vector {};
       foreach ($fieldMap as $fieldName => $fieldType) {
+
+        if (SqlGenerator::skipField($fieldName)) {
+          continue;
+        }
+
         $selectFields->add($fieldName);
       }
 
@@ -77,6 +84,10 @@ class SqlGenerator {
 
       foreach ($fieldMap as $fieldName => $fieldType) {
 
+        if (SqlGenerator::skipField($fieldName)) {
+          continue;
+        }
+        
         // push the field name onto the stack.
         $fields->add($fieldName);
 
@@ -133,6 +144,10 @@ class SqlGenerator {
           continue;
         }
 
+        if (SqlGenerator::skipField($fieldName)) {
+          continue;
+        }
+
         $fieldObj = $obj->fields()->getTypedField($fieldName);
         $fieldValue = $fieldObj->get();
 
@@ -184,6 +199,10 @@ class SqlGenerator {
     } catch (Exception $e) {
       throw $e;
     }
+  }
+
+  private static function skipField(string $fieldName): bool {
+    return substr($fieldName, 0, strlen(SqlGenerator::SKIP_FIELD_PREFIX)) === SqlGenerator::SKIP_FIELD_PREFIX;
   }
 
 }

--- a/src/Zynga/Framework/PgData/V1/PgModel/SqlGenerator.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/SqlGenerator.hh
@@ -87,7 +87,7 @@ class SqlGenerator {
         if (SqlGenerator::skipField($fieldName)) {
           continue;
         }
-        
+
         // push the field name onto the stack.
         $fields->add($fieldName);
 
@@ -174,7 +174,7 @@ class SqlGenerator {
       throw $e;
     }
   }
-  
+
   public static function getDeleteSql(
     QueryableInterface $dbh,
     PgModelInterface $model,
@@ -202,7 +202,9 @@ class SqlGenerator {
   }
 
   private static function skipField(string $fieldName): bool {
-    return substr($fieldName, 0, strlen(SqlGenerator::SKIP_FIELD_PREFIX)) === SqlGenerator::SKIP_FIELD_PREFIX;
+    return
+      substr($fieldName, 0, strlen(SqlGenerator::SKIP_FIELD_PREFIX)) ===
+      SqlGenerator::SKIP_FIELD_PREFIX;
   }
 
 }

--- a/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
@@ -143,7 +143,7 @@ class Writer implements WriterInterface {
       }
 
       // Tombstone from cache first
-      if ($obj->setTombstone() === true && $dataCache->set($obj) === true) {
+      if ($obj->tombstoneRow() === true && $dataCache->set($obj) === true) {
         $dbh = $pgModel->db()->getWriteDatabase();
 
         $where = new PgWhereClause($pgModel);

--- a/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
@@ -142,8 +142,8 @@ class Writer implements WriterInterface {
         );
       }
 
-      // Delete from cache first
-      if ($dataCache->delete($obj) === true) {
+      // Tombstone from cache first
+      if ($obj->setTombstone() === true && $dataCache->set($obj) === true) {
         $dbh = $pgModel->db()->getWriteDatabase();
 
         $where = new PgWhereClause($pgModel);

--- a/src/Zynga/Framework/PgData/V1/PgRow.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow.hh
@@ -18,6 +18,7 @@ abstract class PgRow extends StorableObject implements PgRowInterface {
     parent::__construct();
 
     $this->_ignore_tombstoned = new BoolBox();
+    $this->_ignore_tombstoned->set(false);
     $this->_ignore_tombstoned->setIsRequired(false);
 
     $this->_pgModel = $pgModel;
@@ -52,7 +53,7 @@ abstract class PgRow extends StorableObject implements PgRowInterface {
   public function save(bool $shouldUnlock = true): bool {
     return $this->pgModel()->writer()->save($this, $shouldUnlock);
   }
-  
+
   public function delete(bool $shouldUnlock = true): bool {
     return $this->pgModel()->writer()->delete($this, $shouldUnlock);
   }
@@ -61,7 +62,7 @@ abstract class PgRow extends StorableObject implements PgRowInterface {
     return $this->_ignore_tombstoned->get();
   }
 
-  public function setTombstone(): bool {
+  public function tombstoneRow(): bool {
     $this->_ignore_tombstoned->set(true);
     return $this->_ignore_tombstoned->get();
   }

--- a/src/Zynga/Framework/PgData/V1/PgRow.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow.hh
@@ -7,13 +7,18 @@ use Zynga\Framework\PgData\V1\Interfaces\PgRowInterface;
 use Zynga\Framework\PgData\V1\Exceptions\InvalidPrimaryKeyException;
 use Zynga\Framework\StorableObject\V1\Base as StorableObject;
 use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
+use Zynga\Framework\Type\V1\BoolBox;
 
 abstract class PgRow extends StorableObject implements PgRowInterface {
   private PgModelInterface $_pgModel;
+  public BoolBox $_ignore_tombstoned;
 
   public function __construct(PgModelInterface $pgModel) {
 
     parent::__construct();
+
+    $this->_ignore_tombstoned = new BoolBox();
+    $this->_ignore_tombstoned->setIsRequired(false);
 
     $this->_pgModel = $pgModel;
 
@@ -50,6 +55,15 @@ abstract class PgRow extends StorableObject implements PgRowInterface {
   
   public function delete(bool $shouldUnlock = true): bool {
     return $this->pgModel()->writer()->delete($this, $shouldUnlock);
+  }
+
+  public function isTombstoned(): bool {
+    return $this->_ignore_tombstoned->get();
+  }
+
+  public function setTombstone(): bool {
+    $this->_ignore_tombstoned->set(true);
+    return $this->_ignore_tombstoned->get();
   }
 
 }


### PR DESCRIPTION
In cases where your database is eventually consistent (i.e. a master->replica architecture) deleting a PgData row may result in the deleted item being put back into the cache after a read hits the replica database which still contains the deleted row.

This change adds a new field "tombstone" to the base PgRow. When a row is deleted we:

1- Set the tombstone to true and update the row in the cache
2- Delete the row from the database

When a row is found in the cache we check if the tombstone flag is true and treat it as a not found row maintaining consistency between deletes/reads even in cases where replication lag is significant. 