### PR TITLE
NO-TIKCET: Adding support for pk per shard and retrying on add

### DIFF
--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
@@ -8,7 +8,7 @@ use Zynga\Framework\Type\V1\Interfaces\TypeInterface;
 interface PgRowInterface extends StorableObjectInterface {
   public function pgModel(): PgModelInterface;
   public function getPrimaryKeyIsFromDatabase(): bool;
-  public function getPrimaryKeyNextValue(): TypeInterface;
+  public function getPrimaryKeyNextValue(bool $shouldLoadFromDatabase): TypeInterface;
   public function getPrimaryKey(): string;
   public function getPrimaryKeyTyped(): TypeInterface;
   public function getTableName(): string;

--- a/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Writer.hh
@@ -43,7 +43,7 @@ class Writer implements WriterInterface {
     list($isDefaultValue, $isDefaultError) = $pk->isDefaultValue();
 
     if ($isDefaultValue === true) {
-      $retryOnFailure = true;
+      $retryOnException = true;
       if ($row->getPrimaryKeyIsFromDatabase() === false) {
         $pk->set($row->getPrimaryKeyNextValue(false)->get());
       } else {
@@ -52,13 +52,13 @@ class Writer implements WriterInterface {
         );
       }
     } else {
-      $retryOnFailure = false;
+      $retryOnException = false;
     }
 
     try {
       return $this->addNewRowToDB($row);
     } catch (Exception $e) {
-      if($retryOnFailure == true) {
+      if($retryOnException == true) {
         // Fetch the pk value from DB and update memcache;
         $pk->set($row->getPrimaryKeyNextValue(true)->get());
         return $this->addNewRowToDB($row);

--- a/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
@@ -111,13 +111,19 @@ abstract class PkComesFromMemcache extends PgRow {
 
   public function createPkKeyForMC(): string {
     $writeDatabase = $this->pgModel()->db()->getWriteDatabase();
-    $shardId = 0;
+
     if($writeDatabase instanceof ShardedDriverInterface) {
       $shardId = $writeDatabase->getConfig()->getShardId($writeDatabase->getShardType());
+      $databaseName = $writeDatabase->getConfig()->getDatabaseName();
+    } else if($writeDatabase instanceof DatabaseDriverInterface) {
+      $shardId = 0;
+      $databaseName = $writeDatabase->getConfig()->getCurrentDatabase();
+    } else {
+      throw new Exception("Unsupported database driver");
     }
 
     $tableName = $this->getTableName();
-    $pkKey = 'pgd:'.$shardId.'|'.$tableName.':pk';
+    $pkKey = 'pgd:'.$shardId.'|'.$databaseName.":".$tableName.':pk';
     return $pkKey;
   }
 

--- a/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
@@ -110,9 +110,14 @@ abstract class PkComesFromMemcache extends PgRow {
   }
 
   public function createPkKeyForMC(): string {
-    $connectionString = $this->getConnectionStringFromWriteDatabase();
+    $writeDatabase = $this->pgModel()->db()->getWriteDatabase();
+    $shardId = 0;
+    if($writeDatabase instanceof ShardedDriverInterface) {
+      $shardId = $writeDatabase->getConfig()->getShardId($writeDatabase->getShardType());
+    }
+
     $tableName = $this->getTableName();
-    $pkKey = 'pgd:'.hash("sha256", $connectionString).'|'.$tableName.':pk';
+    $pkKey = 'pgd:'.$shardId.'|'.$tableName.':pk';
     return $pkKey;
   }
 

--- a/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
@@ -25,7 +25,7 @@ abstract class PkComesFromMemcache extends PgRow {
   // In our use case we pull the id off memcache after reading the pk
   // value from the db.
   // --
-  public function getPrimaryKeyNextValue(): TypeInterface {
+  public function getPrimaryKeyNextValue(bool $shouldLoadFromDatabase): TypeInterface {
 
     try {
 
@@ -43,16 +43,18 @@ abstract class PkComesFromMemcache extends PgRow {
         // 3) Make a sha256(connection string)|table:pk
         $pkKey = $this->createPkKeyForMC();
 
-        // 4) Attempt to increment via the memcache driver.
-        $value = $cache->directIncrement($pkKey);
+        if($shouldLoadFromDatabase == false) {
+          // 4) Attempt to increment via the memcache driver.
+          $value = $cache->directIncrement($pkKey);
 
-        // 5) All is well if the value is bigger than 0
-        if ($value > 0) {
-          $id->set($value);
-          return $id;
+          // 5) All is well if the value is bigger than 0
+          if ($value > 0) {
+            $id->set($value);
+            return $id;
+          }
         }
 
-        // 6) If the value is not bigger than 0, attempt to load it from the db.
+        // 6) If the value is not bigger than 0 or $shouldLoadFromDatabase = true, attempt to load it from the db.
         $pkKeyLock = $pkKey.':lock';
         $pkLock = $cache->directAdd($pkKeyLock, 0, 0, 30);
 
@@ -108,10 +110,7 @@ abstract class PkComesFromMemcache extends PgRow {
   }
 
   public function createPkKeyForMC(): string {
-    $writeDatabase = $this->pgModel()->db()->getWriteDatabase();
-
-    $connectionString = '';
-
+    $connectionString = $this->getConnectionStringFromWriteDatabase();
     $tableName = $this->getTableName();
     $pkKey = 'pgd:'.hash("sha256", $connectionString).'|'.$tableName.':pk';
     return $pkKey;

--- a/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow/PkComesFromMemcache.hh
@@ -116,14 +116,14 @@ abstract class PkComesFromMemcache extends PgRow {
       $shardId = $writeDatabase->getConfig()->getShardId($writeDatabase->getShardType());
       $databaseName = $writeDatabase->getConfig()->getDatabaseName();
     } else if($writeDatabase instanceof DatabaseDriverInterface) {
-      $shardId = 0;
+      $shardId = -1;
       $databaseName = $writeDatabase->getConfig()->getCurrentDatabase();
     } else {
       throw new Exception("Unsupported database driver");
     }
 
     $tableName = $this->getTableName();
-    $pkKey = 'pgd:'.$shardId.'|'.$databaseName.":".$tableName.':pk';
+    $pkKey = 'pgd:' . hash("sha256", $shardId.':'.$databaseName.":".$tableName) . ':pk';
     return $pkKey;
   }
 

--- a/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryModelTest.hh
+++ b/src/Zynga/Framework/PgData/V1/Test/ExampleFeature/Model/InventoryModelTest.hh
@@ -201,11 +201,11 @@ class InventoryModelTest extends BaseInventoryTest {
     // stand up the row you'd like to add
     $item = new ItemType($model);
 
-    $firstId = $item->getPrimaryKeyNextValue();
+    $firstId = $item->getPrimaryKeyNextValue(false);
 
     $this->assertGreaterThan(0, $firstId->get());
 
-    $secondId = $item->getPrimaryKeyNextValue();
+    $secondId = $item->getPrimaryKeyNextValue(false);
 
     $this->assertGreaterThan($firstId->get(), $secondId->get());
 


### PR DESCRIPTION
- Update the memcache key for primary key to be stored per shard id. Right now if we add a pk to one shard we skip that key for all other shards effectively reducing primary keys by 16. 

- Retry once on add failure by calculating the pk value from the db. This will fix issues where something was added directly to the DB.