### PR TITLE
Adding support for cache prefix for PgRows

### DIFF
--- a/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
+++ b/src/Zynga/Framework/PgData/V1/Interfaces/PgRowInterface.hh
@@ -17,4 +17,5 @@ interface PgRowInterface extends StorableObjectInterface {
   public function delete(bool $shouldUnlock = true): bool;
   public function tombstoneRow(): bool;
   public function isTombstoned(): bool;
+  public function getCacheKeyPrefix(): string;
 }

--- a/src/Zynga/Framework/PgData/V1/PgRow.hh
+++ b/src/Zynga/Framework/PgData/V1/PgRow.hh
@@ -67,4 +67,8 @@ abstract class PgRow extends StorableObject implements PgRowInterface {
     return $this->_ignore_tombstoned->get();
   }
 
+  public function getCacheKeyPrefix(): string {
+    return "";
+  }
+
 }


### PR DESCRIPTION
This PR adds a new function to the `PgRowInterface`. PgData row models can chose to implement this function to change the cache prefix in the scenario where they decide to invalidate all the keys (i.e. when the model changes). It defaults to an empty string.

