### PR TITLE
Allow non UInt64 results sets

### DIFF
--- a/src/Zynga/Framework/PgData/V1/PgModel/Reader.hh
+++ b/src/Zynga/Framework/PgData/V1/PgModel/Reader.hh
@@ -192,7 +192,7 @@ class Reader implements ReaderInterface {
       $pkTyped = $tobj->getPrimaryKeyTyped();
       $pkType = get_class($pkTyped);
 
-      $cache = new PgCachedResultSet(UInt64Box::class, $pgWhere, $model);
+      $cache = new PgCachedResultSet($pkType, $pgWhere, $model);
 
       return $cache;
 


### PR DESCRIPTION
Currently the code is crashing when deserializing cached where clauses when tables use non integer keys.